### PR TITLE
Changed shell behaviour

### DIFF
--- a/coaster/manage.py
+++ b/coaster/manage.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from sys import stdout
-import os
-import argparse
 
 import flask
 from alembic.config import Config


### PR DESCRIPTION
Usage: `python manage.py shell -e dev` default `flask-script` behaviour `python shell --no-ipython` isn't possible because there is no way to pass flags.

One way to replicate this behaviour is to write `class PatchedShell` and check for `--no-ipython` and `--no-bpython` in `sys.argv` in `run`, is that ok or use argparse ?
