### PR TITLE
SMS Notifications for errors

### DIFF
--- a/coaster/logging.py
+++ b/coaster/logging.py
@@ -70,12 +70,15 @@ class SMSHandler(logging.Handler):
             self.twilio_from = twilio_from
 
     def emit(self, record):
-        if(record.funcName != error_throttle_timestamp['funcName'] or record.lineno != error_throttle_timestamp['lineno'] or (datetime.now() - error_throttle_timestamp['timestamp']) > timedelta(minutes=5)):
+        # TODO Find linenumber and function name from exception's log record
+        # if(record.funcName != error_throttle_timestamp['funcName'] or record.lineno != error_throttle_timestamp['lineno'] or (datetime.now() - error_throttle_timestamp['timestamp']) > timedelta(minutes=5)):
+        if ((datetime.now() - error_throttle_timestamp['timestamp']) > timedelta(minutes=5)):
             for phonenumber in self.phonenumbers:
                 self.sendsms(phonenumber, 'Error in {name}. Please check your email for details'.format(name=self.app_name))
-            error_throttle_timestamp['funcName'] = record.funcName
-            error_throttle_timestamp['lineno'] = record.lineno
+            # error_throttle_timestamp['funcName'] = record.funcName
+            # error_throttle_timestamp['lineno'] = record.lineno
             error_throttle_timestamp['timestamp'] = datetime.now()
+            print error_throttle_timestamp
 
     def sendsms(self, number, message):
         try:


### PR DESCRIPTION
SMSs are sent to a defined list of numbers when a log with level ERROR occurs (Similar to the SMTP system currently in place)

SMSs are throttled based on the following rules
* SMSes aren't sent if an error had occurred in the last 5 minutes.

#### Required config
```python
ADMIN_NUMBERS = []
SMS_EXOTEL_SID = ''
SMS_EXOTEL_TOKEN = ''
SMS_EXOTEL_FROM = ''
SMS_TWILIO_SID = ''
SMS_TWILIO_TOKEN = ''
SMS_TWILIO_FROM = ''
```