### PR TITLE
Fix issue #66

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
 * manage.py's shell now allows additional context to be made available in locals().
 * coaster.db now provides a custom SQLAlchemy session with additional helper methods,
   starting with one: ``add_and_commit``, which rolls back if the commit fails.
+* Removed ``one_or_none`` in favor of SQLAlchemy's implementation of the same in 1.0.9
 
 0.4.3
 -----

--- a/coaster/sqlalchemy.py
+++ b/coaster/sqlalchemy.py
@@ -26,16 +26,6 @@ class Query(BaseQuery):
     Extends flask.ext.sqlalchemy.BaseQuery to add additional helper methods.
     """
 
-    def one_or_none(self):
-        """
-        Like :meth:`one` but returns None if no results are found. Raises an exception
-        if multiple results are found.
-        """
-        try:
-            return self.one()
-        except NoResultFound:
-            return None
-
     def notempty(self):
         """
         Returns the equivalent of ``bool(query.count())`` but using an efficient

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requires = [
     'webassets',
     'Flask-Script==0.5.3',
     'Flask-SQLAlchemy',
-    'SQLAlchemy',
+    'SQLAlchemy>=1.0.9',
     'docflow>=0.3.2',
     'html2text',
     'py-bcrypt',


### PR DESCRIPTION
Mark Query class's one_or_none() deprecated in favor of using
SQL-Alchemy's native one_or_none.