### PR TITLE
StateManager updates (resolves #165)

### DIFF
--- a/coaster/sqlalchemy/statemanager.py
+++ b/coaster/sqlalchemy/statemanager.py
@@ -163,7 +163,7 @@ States can also be used for database queries when accessed from the class::
     MyPost.query.filter(MyPost.state.RECENT)
 
 This works because :class:`StateManager`, :class:`ManagedState`
-and :class:`ManagedStateGroup` behave in four different ways, depending on
+and :class:`ManagedStateGroup` behave in three different ways, depending on
 context:
 
 1. During class definition, the state manager returns the managed state. All
@@ -174,14 +174,11 @@ context:
    managed state instance. If accessed via the class, the managed state returns
    a SQLAlchemy filter condition.
 
-3. After class definition, if accessed via an instance, the managed state tests
-   if it is currently active and returns a boolean result.
-
-4. :meth:`StateManager.current` returns a dictionary of all currently valid
-   managed states and state groups, wrapped in
-   :class:`ManagedStateWrapper` which holds the context of the object on which
-   the method was called. Calling these states will return True as long as the
-   state remains unchanged.
+3. After class definition, if accessed via an instance, the managed state
+   returns itself wrapped in :class:`ManagedStateWrapper` (which holds context
+   for the instance). This is an object that evaluates to ``True`` if the state
+   is active, ``False`` otherwise. It also provides pass-through access to
+   all attributes of the managed state.
 
 States can be changed via transitions, defined as methods with the
 :meth:`~StateManager.transition` decorator. They add more power and safeguards

--- a/tests/test_statemanager.py
+++ b/tests/test_statemanager.py
@@ -30,6 +30,7 @@ class MY_STATE(LabeledEnum):
 
     __order__ = (DRAFT, PENDING, PUBLISHED)
     UNPUBLISHED = {DRAFT, PENDING}
+    PUBLISHED_AND_AFTER = {PUBLISHED}
 
 
 class REVIEW_STATE(LabeledEnum):
@@ -268,9 +269,8 @@ class TestStateManager(unittest.TestCase):
         with self.assertRaises(ValueError):
             state.add_state_group('MIXED1', state.PUBLISHED, state.RECENT)
         # Can't group a conditional state with group containing main state
-        state.add_conditional_state('TEST', state.DRAFT, lambda obj: True)
         with self.assertRaises(ValueError):
-            state.add_state_group('MIXED2', state.UNPUBLISHED, state.TEST)
+            state.add_state_group('MIXED2', state.PUBLISHED_AND_AFTER, state.RECENT)
 
     def test_sql_query_single_value(self):
         """

--- a/tests/test_statemanager.py
+++ b/tests/test_statemanager.py
@@ -59,7 +59,8 @@ class MyPost(BaseMixin, db.Model):
 
     # Conditional states (adds ManagedState instances)
     state.add_conditional_state('RECENT', state.PUBLISHED,
-        lambda post: post.datetime > datetime.utcnow() - timedelta(hours=1))
+        lambda post: post.datetime > datetime.utcnow() - timedelta(hours=1),
+        label=('recent', "Recently published"))
 
     # State groups (apart from those in the LabeledEnum), used here to include the
     # conditional state in a group. Adds ManagedStateGroup instances
@@ -143,6 +144,10 @@ class TestStateManager(unittest.TestCase):
             state.add_conditional_state('TEST_STATE1', MY_STATE.DRAFT, lambda post: True)
         with self.assertRaises(ValueError):
             state.add_conditional_state('TEST_STATE2', reviewstate.UNSUBMITTED, lambda post: True)
+
+    def test_conditional_state_label(self):
+        """Conditional states can have labels"""
+        self.assertEqual(MyPost.__dict__['state'].RECENT.label.name, 'recent')
 
     def test_transition_invalid_from_to(self):
         """

--- a/tests/test_statemanager.py
+++ b/tests/test_statemanager.py
@@ -517,11 +517,16 @@ class TestStateManager(unittest.TestCase):
         draft = MyPost.__dict__['state'].DRAFT
         wdraft = ManagedStateWrapper(draft, self.post, MyPost)
         self.assertEqual(draft.value, wdraft.value)
-        self.assertTrue(wdraft())
+        self.assertTrue(wdraft())  # Result is False
+        self.assertTrue(wdraft)    # Object is falsy
         self.assertEqual(self.post.state.DRAFT, wdraft)
         self.post.submit()
         self.assertFalse(wdraft())
-        self.assertEqual(self.post.state.DRAFT, wdraft)
+        self.assertFalse(wdraft)
+        self.assertEqual(self.post.state.DRAFT(), wdraft())       # False == False
+        self.assertEqual(self.post.state.DRAFT, wdraft)           # Object remains the same even if not active
+        self.assertNotEqual(self.post.state.PENDING, wdraft)      # These objects don't match
+        self.assertNotEqual(self.post.state.PENDING(), wdraft())  # True != False
 
         with self.assertRaises(TypeError):
             ManagedStateWrapper(MY_STATE.DRAFT, self.post)

--- a/tests/test_statemanager.py
+++ b/tests/test_statemanager.py
@@ -183,7 +183,6 @@ class TestStateManager(unittest.TestCase):
         A post has a state that can be tested with statemanager.NAME
         """
         self.assertEqual(self.post._state, MY_STATE.DRAFT)
-        self.assertEqual(self.post.state(), MY_STATE.DRAFT)
         self.assertEqual(self.post.state.value, MY_STATE.DRAFT)
         self.assertTrue(self.post.state.DRAFT)
         self.assertFalse(self.post.state.PENDING)
@@ -327,14 +326,14 @@ class TestStateManager(unittest.TestCase):
         """
         `submit` transition works
         """
-        self.assertEqual(self.post.state(), MY_STATE.DRAFT)
+        self.assertEqual(self.post.state.value, MY_STATE.DRAFT)
         self.post.submit()
-        self.assertEqual(self.post.state(), MY_STATE.PENDING)
+        self.assertEqual(self.post.state.value, MY_STATE.PENDING)
         with self.assertRaises(StateTransitionError):
             # Can only be called in draft state, which we are no longer in
             self.post.submit()
         # If there's an error, the state does not change
-        self.assertEqual(self.post.state(), MY_STATE.PENDING)
+        self.assertEqual(self.post.state.value, MY_STATE.PENDING)
 
     def test_transition_publish_invalid(self):
         """

--- a/tests/test_statemanager.py
+++ b/tests/test_statemanager.py
@@ -148,6 +148,7 @@ class TestStateManager(unittest.TestCase):
     def test_conditional_state_label(self):
         """Conditional states can have labels"""
         self.assertEqual(MyPost.__dict__['state'].RECENT.label.name, 'recent')
+        self.assertEqual(self.post.state.RECENT.label.name, 'recent')
 
     def test_transition_invalid_from_to(self):
         """
@@ -515,13 +516,13 @@ class TestStateManager(unittest.TestCase):
     def test_managed_state_wrapper(self):
         """ManagedStateWrapper will only wrap a managed state or group"""
         draft = MyPost.__dict__['state'].DRAFT
-        wdraft = ManagedStateWrapper(draft, self.post)
+        wdraft = ManagedStateWrapper(draft, self.post, MyPost)
         self.assertEqual(draft.value, wdraft.value)
         self.assertTrue(wdraft())
-        self.assertEqual(self.post.state.DRAFT, wdraft())
+        self.assertEqual(self.post.state.DRAFT, wdraft)
         self.post.submit()
         self.assertFalse(wdraft())
-        self.assertEqual(self.post.state.DRAFT, wdraft())
+        self.assertEqual(self.post.state.DRAFT, wdraft)
 
         with self.assertRaises(TypeError):
             ManagedStateWrapper(MY_STATE.DRAFT, self.post)


### PR DESCRIPTION
These commits introduce a breaking change, but in unused functionality. There is also a contestable choice in using `bestmatch()` for `state.label`. This suits a current requirement in Funnel, but may be a problem elsewhere, and will therefore need revisiting.

For code review, please look at each commit separately. It will be easier to understand.