### PR TITLE
ClassView fixes and improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@
 * New: ``coaster.views.requires_permission`` decorator
 * New: ``coaster.views.classview`` provides a new take on organising views
   into a class
+* New: ``coaster.utils.classmethodproperty``: like a property, but for class
+  methods
 
 
 0.6.0

--- a/coaster/views/classview.py
+++ b/coaster/views/classview.py
@@ -16,7 +16,6 @@ from werkzeug.routing import parse_rule
 from werkzeug.local import LocalProxy
 from flask import _request_ctx_stack, has_request_context, request, redirect, make_response
 from ..auth import current_auth, add_auth_attribute
-from ..sqlalchemy import PermissionMixin
 
 __all__ = [
     'route', 'rulejoin', 'current_view',  # Functions
@@ -550,7 +549,8 @@ class InstanceLoader(object):
             obj = query.one_or_404()
             # Determine permissions available on the object for the current actor,
             # but only if the view method has a requires_permission decorator
-            if hasattr(self.current_method.wrapped_func, 'requires_permission') and isinstance(obj, PermissionMixin):
+            if (hasattr(self.current_method.wrapped_func, 'requires_permission') and
+                    hasattr(obj, 'current_permissions')):
                 perms = obj.current_permissions
                 if hasattr(current_auth, 'permissions'):
                     perms = perms | current_auth.permissions

--- a/coaster/views/classview.py
+++ b/coaster/views/classview.py
@@ -181,8 +181,6 @@ class ViewDecorator(object):
                 use_options.update(class_options)
                 endpoint = use_options.pop('endpoint', self.endpoint)
                 self.endpoints.add(endpoint)
-                # If there are multiple rules with custom endpoint names, the last route's prevails here
-                self.endpoint = endpoint
                 use_rule = rulejoin(class_rule, method_rule)
                 app.add_url_rule(use_rule, endpoint, view_func, **use_options)
                 if callback:

--- a/tests/test_views_classview.py
+++ b/tests/test_views_classview.py
@@ -40,7 +40,8 @@ class ViewDocument(BaseNameMixin, db.Model):
 class ScopedViewDocument(BaseScopedNameMixin, db.Model):
     __tablename__ = 'scoped_view_document'
     parent_id = db.Column(None, db.ForeignKey('view_document.id'), nullable=False)
-    parent = db.relationship(ViewDocument, backref=db.backref('children', cascade='all, delete-orphan'))
+    view_document = db.relationship(ViewDocument, backref=db.backref('children', cascade='all, delete-orphan'))
+    parent = db.synonym('view_document')
 
     __roles__ = {
         'all': {

--- a/tests/test_views_classview.py
+++ b/tests/test_views_classview.py
@@ -81,13 +81,13 @@ class IndexView(ClassView):
     def current_view_is_self(self):
         return str(current_view == self)
 
-    @route('current_view/current_method_is_self')
-    def current_method_is_self(self):
-        return str(current_view.current_method.name == 'current_method_is_self')
+    @route('current_view/current_handler_is_self')
+    def current_handler_is_self(self):
+        return str(current_view.current_handler.name == 'current_handler_is_self')
 
-    @route('current_view/current_method_is_wrapper')
-    def current_method_is_wrapper(self):
-        return str(current_view.current_method == self.current_method_is_wrapper)
+    @route('current_view/current_handler_is_wrapper')
+    def current_handler_is_wrapper(self):
+        return str(current_view.current_handler == self.current_handler_is_wrapper)
 
 IndexView.init_app(app)
 
@@ -258,12 +258,12 @@ class TestClassView(unittest.TestCase):
         rv = self.client.get('/current_view')
         assert rv.data == b'True'
 
-    def test_current_method_is_self(self):
-        rv = self.client.get('/current_view/current_method_is_self')
+    def test_current_handler_is_self(self):
+        rv = self.client.get('/current_view/current_handler_is_self')
         assert rv.data == b'True'
 
-    def test_current_method_is_wrapper(self):
-        rv = self.client.get('/current_view/current_method_is_wrapper')
+    def test_current_handler_is_wrapper(self):
+        rv = self.client.get('/current_view/current_handler_is_wrapper')
         assert rv.data == b'True'
 
     def test_document_404(self):
@@ -399,7 +399,7 @@ class TestClassView(unittest.TestCase):
 
     def test_viewlist(self):
         assert IndexView.__views__ == {
-            'current_method_is_self', 'current_method_is_wrapper', 'current_view_is_self', 'index', 'page'}
+            'current_handler_is_self', 'current_handler_is_wrapper', 'current_view_is_self', 'index', 'page'}
 
     def test_modelview_instanceloader_view(self):
         """Test document view in ModelView with InstanceLoader"""

--- a/tests/test_views_classview.py
+++ b/tests/test_views_classview.py
@@ -79,9 +79,13 @@ class IndexView(ClassView):
     def current_view_is_self(self):
         return str(current_view == self)
 
-    @route('current_view/current_method')
+    @route('current_view/current_method_is_self')
     def current_method_is_self(self):
         return str(current_view.current_method.name == 'current_method_is_self')
+
+    @route('current_view/current_method_is_wrapper')
+    def current_method_is_wrapper(self):
+        return str(current_view.current_method == self.current_method_is_wrapper)
 
 IndexView.init_app(app)
 
@@ -248,8 +252,12 @@ class TestClassView(unittest.TestCase):
         rv = self.client.get('/current_view')
         assert rv.data == b'True'
 
-    def test_current_method(self):
-        rv = self.client.get('/current_view/current_method')
+    def test_current_method_is_self(self):
+        rv = self.client.get('/current_view/current_method_is_self')
+        assert rv.data == b'True'
+
+    def test_current_method_is_wrapper(self):
+        rv = self.client.get('/current_view/current_method_is_wrapper')
         assert rv.data == b'True'
 
     def test_document_404(self):


### PR DESCRIPTION
Breaking change since before_request no longer gets the ‘view’
parameter. If needed, it can consult self.current_handler instead.