### PR TITLE
made current_auth return a boolean

### DIFF
--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -114,6 +114,10 @@ class CurrentAuth(object):
 
     Check if you have a valid actor in the current request::
 
+        if current_auth:
+
+    which is equivalent to,
+
         if current_auth.is_authenticated:
 
     Reverse check, for anonymous user. Your login manager may or may not
@@ -143,6 +147,14 @@ class CurrentAuth(object):
 
     def __repr__(self):  # pragma: no cover
         return 'CurrentAuth(%s)' % repr(self.actor)
+
+    def __bool__(self):
+        """
+        Returns ``True`` if user is authenticated, ``False`` if not.
+        """
+        return self.is_authenticated
+
+    __nonzero__ = __bool__  # for backward compatibility in Python 2.x
 
     @property
     def is_anonymous(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -132,6 +132,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
     def test_current_auth_without_user(self):
         self.assertTrue(current_auth.is_anonymous)
         self.assertFalse(current_auth.is_authenticated)
+        self.assertFalse(current_auth)
         self.assertIsNone(current_auth.user)
         self.assertIsNone(current_auth.actor)
 
@@ -141,6 +142,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
 
         self.assertFalse(current_auth.is_anonymous)
         self.assertTrue(current_auth.is_authenticated)
+        self.assertTrue(current_auth)
         self.assertIsNotNone(current_auth.user)
         self.assertEqual(current_auth.user, user)
         self.assertEqual(current_auth.actor, user)
@@ -164,6 +166,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
 
         self.assertFalse(current_auth.is_anonymous)
         self.assertTrue(current_auth.is_authenticated)
+        self.assertTrue(current_auth)
         self.assertIsNotNone(current_auth.user)
         self.assertEqual(current_auth.user, user)
         self.assertEqual(current_auth.actor, user)
@@ -171,6 +174,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
     def test_current_auth_with_user_loaded(self):
         self.assertTrue(current_auth.is_anonymous)
         self.assertFalse(current_auth.is_authenticated)
+        self.assertFalse(current_auth)
         self.assertIsNone(current_auth.user)
         self.assertIsNone(current_auth.actor)
 
@@ -179,6 +183,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
 
         self.assertFalse(current_auth.is_anonymous)
         self.assertTrue(current_auth.is_authenticated)
+        self.assertTrue(current_auth)
         self.assertIsNotNone(current_auth.user)
         self.assertEqual(current_auth.user, user)
         self.assertEqual(current_auth.actor, user)
@@ -186,6 +191,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
     def test_anonymous_user(self):
         self.assertTrue(current_auth.is_anonymous)
         self.assertFalse(current_auth.is_authenticated)
+        self.assertFalse(current_auth)
         self.assertIsNone(current_auth.user)
 
         user = AnonymousUser()
@@ -196,6 +202,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
         self.assertIsNotNone(current_auth.user)
         # is_authenticated == True, since there is an actor
         self.assertTrue(current_auth.is_authenticated)
+        self.assertTrue(current_auth)
         self.assertIsNotNone(current_auth.actor)
         self.assertEqual(current_auth.user, user)
         self.assertEqual(current_auth.actor, user)
@@ -208,6 +215,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
     def test_other_actor_authenticated(self):
         self.assertTrue(current_auth.is_anonymous)
         self.assertFalse(current_auth.is_authenticated)
+        self.assertFalse(current_auth)
         self.assertIsNone(current_auth.user)
 
         client = Client()
@@ -215,6 +223,7 @@ class TestCurrentUserWithLoginManager(unittest.TestCase):
 
         self.assertFalse(current_auth.is_anonymous)
         self.assertTrue(current_auth.is_authenticated)
+        self.assertTrue(current_auth)
         self.assertIsNone(current_auth.user)  # It's not the user
         self.assertEqual(current_auth.client, client)  # There's now a client attribute
         self.assertEqual(current_auth.actor, client)   # The client is also the actor


### PR DESCRIPTION
Fixes #188. 

Now `current_auth` returns a boolean which is equivalent to `current_auth.is_authenticated`.