### PR TITLE
Removed deprecated safe_mode from Markdown()

### DIFF
--- a/coaster/gfm.py
+++ b/coaster/gfm.py
@@ -16,6 +16,7 @@ https://gist.github.com/Wilfred/901706
 
 from markupsafe import Markup
 from markdown import Markdown
+from markdown.extensions import Extension
 import re
 from .utils import sanitize_html, VALID_TAGS
 
@@ -37,15 +38,20 @@ GFM_TAGS['th'] = ['align', 'char', 'charoff', 'colspan', 'rowspan', 'valign']
 GFM_TAGS['thead'] = ['align', 'char', 'charoff', 'valign']
 GFM_TAGS['tr'] = ['align', 'char', 'charoff', 'valign']
 
-markdown_convert_text = Markdown(safe_mode='escape', output_format='html5',
-    enable_attributes=False,
-    extensions=['markdown.extensions.codehilite', 'markdown.extensions.smarty'],
+
+class EscapeHtml(Extension):
+    def extendMarkdown(self, md):
+        md.preprocessors.deregister('html_block')
+        md.inlinePatterns.deregister('html')
+
+
+markdown_convert_text = Markdown(output_format='html5', enable_attributes=False,
+    extensions=['markdown.extensions.codehilite', 'markdown.extensions.smarty', EscapeHtml()],
     extension_configs={'codehilite': {'css_class': 'syntax'}}
     ).convert
 
 
-markdown_convert_html = Markdown(safe_mode=False, output_format='html5',
-    enable_attributes=True,
+markdown_convert_html = Markdown(output_format='html5', enable_attributes=True,
     extensions=['markdown.extensions.codehilite', 'markdown.extensions.smarty'],
     extension_configs={'codehilite': {'css_class': 'syntax'}}
     ).convert
@@ -168,4 +174,5 @@ def markdown(text, html=False, valid_tags=GFM_TAGS):
     if html:
         return Markup(sanitize_html(markdown_convert_html(gfm(text)), valid_tags=valid_tags))
     else:
+        print markdown_convert_text(gfm(text))
         return Markup(markdown_convert_text(gfm(text)))

--- a/coaster/gfm.py
+++ b/coaster/gfm.py
@@ -40,18 +40,23 @@ GFM_TAGS['tr'] = ['align', 'char', 'charoff', 'valign']
 
 
 class EscapeHtml(Extension):
+    """
+    Extension to escape HTML tags to use with Markdown()
+    This replaces `safe_mode='escape`
+    Ref: https://python-markdown.github.io/change_log/release-3.0/#safe_mode-and-html_replacement_text-keywords-deprecated
+    """
     def extendMarkdown(self, md):
         md.preprocessors.deregister('html_block')
         md.inlinePatterns.deregister('html')
 
 
-markdown_convert_text = Markdown(output_format='html5', enable_attributes=False,
+markdown_convert_text = Markdown(output_format='html',
     extensions=['markdown.extensions.codehilite', 'markdown.extensions.smarty', EscapeHtml()],
     extension_configs={'codehilite': {'css_class': 'syntax'}}
     ).convert
 
 
-markdown_convert_html = Markdown(output_format='html5', enable_attributes=True,
+markdown_convert_html = Markdown(output_format='html',
     extensions=['markdown.extensions.codehilite', 'markdown.extensions.smarty'],
     extension_configs={'codehilite': {'css_class': 'syntax'}}
     ).convert

--- a/coaster/gfm.py
+++ b/coaster/gfm.py
@@ -174,5 +174,4 @@ def markdown(text, html=False, valid_tags=GFM_TAGS):
     if html:
         return Markup(sanitize_html(markdown_convert_html(gfm(text)), valid_tags=valid_tags))
     else:
-        print markdown_convert_text(gfm(text))
         return Markup(markdown_convert_text(gfm(text)))


### PR DESCRIPTION
Markdown library has removed `safe_mode` from `Markdown()` in version 3.0 and recommends using 3rd party library like Bleach for cleaning strings. Or using extensions to achieve `safe_mode=escape`.

Ref: https://github.com/Python-Markdown/markdown/blob/f51125d01b88067d8523e9706cfa4558b3808222/docs/change_log/release-3.0.md#safe_mode-and-html_replacement_text-keywords-deprecated