### PR TITLE
nullint can now handle ValueError and returns None if can't be cast

### DIFF
--- a/coaster/utils/misc.py
+++ b/coaster/utils/misc.py
@@ -557,16 +557,21 @@ def getbool(value):
 
 def nullint(value):
     """
-    Return int(value) if bool(value) is not False. Return None otherwise.
-    Useful for coercing optional values to an integer.
+    Return int(value) if bool(value) is not False and value can be cast to integer.
+    Return None otherwise. Useful for coercing optional values to an integer.
 
     >>> nullint('10')
     10
     >>> nullint('') is None
     True
+    >>> nullint('foobar') is None
+    True
     """
     if value:
-        return int(value)
+        try:
+            return int(value)
+        except ValueError:
+            return
 
 
 def nullstr(value):


### PR DESCRIPTION
This is useful wherever we need to cast a string to integer and have to do type check every time.