### PR TITLE
Support for multiple models in url_for and ModelView. Resolves #208

### DIFF
--- a/coaster/sqlalchemy/mixins.py
+++ b/coaster/sqlalchemy/mixins.py
@@ -223,9 +223,9 @@ class UrlForMixin(object):
             if isinstance(attr, tuple):
                 # attr is a tuple containing:
                 # 1. ('parent', 'name') --> self.parent.name
-                # 2. ('@entity', 'name') --> kwargs['entity'].name
-                if attr[0].startswith('@'):
-                    item = kwargs.pop(attr[0][1:])
+                # 2. ('**entity', 'name') --> kwargs['entity'].name
+                if attr[0].startswith('**'):
+                    item = kwargs.pop(attr[0][2:])
                     attr = attr[1:]
                 else:
                     item = self

--- a/coaster/sqlalchemy/mixins.py
+++ b/coaster/sqlalchemy/mixins.py
@@ -201,7 +201,7 @@ class UrlForMixin(object):
     """
     Provides a :meth:`url_for` method used by BaseMixin-derived classes
     """
-    #: Mapping of {app: {action: (endpoint, {param: attr})}}, where attr is a string or tuple of strings.
+    #: Mapping of {app: {action: (endpoint, {param: attr}, _external)}}, where attr is a string or tuple of strings.
     #: The same action can point to different endpoints in different apps. The app may also be None as fallback.
     #: Each subclass will get its own dictionary. This particular dictionary is only used as an inherited fallback.
     url_for_endpoints = {None: {}}
@@ -221,7 +221,14 @@ class UrlForMixin(object):
         params = {}
         for param, attr in list(paramattrs.items()):
             if isinstance(attr, tuple):
-                item = self
+                # attr is a tuple containing:
+                # 1. ('parent', 'name') --> self.parent.name
+                # 2. ('@entity', 'name') --> kwargs['entity'].name
+                if attr[0].startswith('@'):
+                    item = kwargs.pop(attr[0][1:])
+                    attr = attr[1:]
+                else:
+                    item = self
                 for subattr in attr:
                     item = getattr(item, subattr)
                 params[param] = item

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -44,7 +44,7 @@ def doc_upper(doc):
 # The first `other` refers to `<other>` in the URL. The second refers
 # to the parameter given to `NamedDocument.url_for` in the test below.
 @app1.route('/<doc>/with/<other>')
-@NamedDocument.is_url_for('with', doc='name', other='@other.name')
+@NamedDocument.is_url_for('with', doc='name', other='**other.name')
 def doc_with(doc, other):
     return u'{} {} {}'.format(doc, 'with', other)
 

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -40,6 +40,15 @@ def doc_upper(doc):
     return u'{} {}'.format('upper', doc)
 
 
+# The unusual parameter `other='@other.name'` requires an explanation.
+# The first `other` refers to `<other>` in the URL. The second refers
+# to the parameter given to `NamedDocument.url_for` in the test below.
+@app1.route('/<doc>/with/<other>')
+@NamedDocument.is_url_for('with', doc='name', other='@other.name')
+def doc_with(doc, other):
+    return u'{} {} {}'.format(doc, 'with', other)
+
+
 @app1.route('/<container>/<doc>')
 @ScopedNamedDocument.is_url_for('view', container='parent.id', doc='name')
 def sdoc_view(container, doc):
@@ -173,6 +182,16 @@ class TestUrlFor(TestUrlForBase):
 
         # This action is only available in this app
         assert doc1.url_for('app_only') == '/document1/app_only'
+
+    def test_linked_doc(self):
+        """URLs linking two unrelated models are possible"""
+        doc1 = NamedDocument(name=u'document1', title=u"Document 1")
+        doc2 = NamedDocument(name=u'document2', title=u"Document 2")
+        self.session.add_all([doc1, doc2])
+        self.session.commit()
+
+        # url_for is given an object and extracts an attribute from it
+        assert doc1.url_for('with', other=doc2) == '/document1/with/document2'
 
 
 class TestUrlFor2(TestUrlForBase):

--- a/tests/test_views_classview.py
+++ b/tests/test_views_classview.py
@@ -245,7 +245,7 @@ class MultiDocumentView(UrlForView, ModelView):
     model = ViewDocument
     route_model_map = {
         'doc1': 'name',
-        'doc2': '@doc2.url_name'
+        'doc2': '**doc2.url_name'
     }
 
     def loader(self, doc1, doc2):


### PR DESCRIPTION
This PR closes the functionality gap between `load_models` and `ModelView`. In cases where the child has no backref to its parent, the parent is responsible for generating URLs to the child, and will expect to receive the child as a parameter to `url_for`.