### PR TITLE
Added UrlType

### DIFF
--- a/coaster/sqlalchemy/columns.py
+++ b/coaster/sqlalchemy/columns.py
@@ -7,7 +7,6 @@ SQLAlchemy column types
 
 from __future__ import absolute_import
 import simplejson
-from urlparse import urlparse
 from sqlalchemy import Column, UnicodeText, Unicode
 from sqlalchemy.types import UserDefinedType, TypeDecorator, TEXT
 from sqlalchemy.orm import composite
@@ -16,6 +15,10 @@ from sqlalchemy_utils.types import UUIDType, URLType as URLTypeBase  # NOQA
 from flask import Markup
 import six
 from ..gfm import markdown
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 __all__ = ['JsonDict', 'MarkdownComposite', 'MarkdownColumn', 'UUIDType', 'UrlType']
 

--- a/coaster/sqlalchemy/columns.py
+++ b/coaster/sqlalchemy/columns.py
@@ -186,12 +186,13 @@ def MarkdownColumn(name, deferred=False, group=None, **kwargs):
 
 
 class UrlType(URLTypeBase):
-    impl = Unicode(2000)
+    impl = UnicodeText
 
     def __init__(self, schemes=('http', 'https')):
         """
         :param schemes: Valid URL schemes
         """
+        super(URLTypeBase, self).__init__()
         self.schemes = schemes
 
     def process_bind_param(self, value, dialect):

--- a/coaster/sqlalchemy/columns.py
+++ b/coaster/sqlalchemy/columns.py
@@ -8,7 +8,7 @@ SQLAlchemy column types
 from __future__ import absolute_import
 import simplejson
 from urlparse import urlparse
-from sqlalchemy import Column, UnicodeText
+from sqlalchemy import Column, UnicodeText, Unicode
 from sqlalchemy.types import UserDefinedType, TypeDecorator, TEXT
 from sqlalchemy.orm import composite
 from sqlalchemy.ext.mutable import Mutable, MutableComposite
@@ -186,6 +186,8 @@ def MarkdownColumn(name, deferred=False, group=None, **kwargs):
 
 
 class UrlType(URLTypeBase):
+    impl = Unicode(2000)
+
     def __init__(self, schemes=('http', 'https')):
         """
         :param schemes: Valid URL schemes

--- a/coaster/sqlalchemy/columns.py
+++ b/coaster/sqlalchemy/columns.py
@@ -7,14 +7,14 @@ SQLAlchemy column types
 
 from __future__ import absolute_import
 import simplejson
-from sqlalchemy import Column, UnicodeText, Unicode
+from sqlalchemy import Column, UnicodeText
 from sqlalchemy.types import UserDefinedType, TypeDecorator, TEXT
 from sqlalchemy.orm import composite
 from sqlalchemy.ext.mutable import Mutable, MutableComposite
 from sqlalchemy_utils.types import UUIDType, URLType as URLTypeBase  # NOQA
 from flask import Markup
+from furl import furl
 import six
-from six.moves.urllib import parse
 from ..gfm import markdown
 
 __all__ = ['JsonDict', 'MarkdownComposite', 'MarkdownColumn', 'UUIDType', 'UrlType']
@@ -106,6 +106,7 @@ class MutableDict(Mutable, dict):
         dict.__delitem__(self, key)
         self.changed()
 
+
 MutableDict.associate_with(JsonDict)
 
 
@@ -182,47 +183,42 @@ def MarkdownColumn(name, deferred=False, group=None, **kwargs):
         Column(name + '_text', UnicodeText, **kwargs),
         Column(name + '_html', UnicodeText, **kwargs),
         deferred=deferred, group=group or name
-        )
+    )
 
 
 class UrlType(URLTypeBase):
     """
-    Create a TEXT type column that validates URLs and creates a ``furl`` object.
-    Based on URLType_ from SQLAlchemy-Utils.
+    Extension of URLType_ from SQLAlchemy-Utils that adds basic validation to
+    ensure URLs are well formed. Parses the value into a :class:`furl` object,
+    allowing manipulation of
 
     .. _URLType: https://sqlalchemy-utils.readthedocs.io/en/latest/data_types.html#module-sqlalchemy_utils.types.url
 
-    :param schemes: Valid URL schemes
-    :param relative_scheme: Whether relative scheme is allowed. False by default.
-    :param relative_path: Whether relative path is allowed. False by default. If it's allowed,
-        ``relative_scheme`` is allowed as well.
+    :param schemes: Valid URL schemes. Use `None` to allow any scheme, `()` for no scheme
+    :param optional_scheme: Schemes are optional (allows URLs starting with ``//``)
+    :param optional_host: Allow URLs without a hostname (required for ``mailto`` and ``file`` schemes)
     """
     impl = UnicodeText
 
-    def __init__(self, schemes=('http', 'https'), relative_path=False, relative_scheme=False):
+    def __init__(self, schemes=('http', 'https'), optional_scheme=False, optional_host=False):
         super(URLTypeBase, self).__init__()
         self.schemes = schemes
-        self.relative_path = relative_path
-        self.relative_scheme = relative_scheme if not relative_path else True
+        self.optional_host = optional_host
+        self.optional_scheme = optional_scheme
 
     def process_bind_param(self, value, dialect):
         value = super(UrlType, self).process_bind_param(value, dialect)
         if value:
-            parsed = parse.urlparse(value)
+            parsed = furl(value)
+            # If scheme is present, it must be valid
+            # If not present, the optional flag must be True
             if parsed.scheme:
-                # E.g. https://example.com/test
                 if self.schemes is not None and parsed.scheme not in self.schemes:
-                    raise ValueError(u"'{}' is not a valid scheme for this column".format(parsed.scheme))
-                elif not parsed.netloc:
-                    raise ValueError(u"Invalid URL as it does not have a host name")
-            else:
-                # E.g. //example.com/test or example.com/test
-                if not self.relative_scheme:
-                    raise ValueError(u"'{}' does not a have a scheme".format(value))
-                if not parsed.netloc and parsed.path:
-                    # E.g. example.com/test
-                    if not self.relative_path:
-                        raise ValueError(u"'{}' does not a have a valid TLD".format(value))
-                else:
-                    pass
+                    raise ValueError("Invalid URL scheme")
+            elif not self.optional_scheme:
+                raise ValueError("Missing URL scheme")
+
+            # Host may be missing only if optional
+            if not parsed.host and not self.optional_host:
+                raise ValueError(u"Missing URL host".format(value))
         return value

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ requires = [
     'markupsafe',
     'blinker',
     'Flask>=1.0',
+    'furl',
 ]
 
 if PY2:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -612,6 +612,12 @@ class TestCoasterModels(unittest.TestCase):
             self.session.add(m1)
             self.session.commit()
 
+    def test_urltype_invalid_schemaless(self):
+        with self.assertRaises(StatementError):
+            m2 = MyUrlModel(url=u"//example.com")
+            self.session.add(m2)
+            self.session.commit()
+
     def test_urltype_invalid_without_host(self):
         with self.assertRaises(StatementError):
             m2 = MyUrlModel(url=u"https:///test")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -119,6 +119,11 @@ class MyData(db.Model):
     __tablename__ = 'my_data'
     id = Column(Integer, primary_key=True)
     data = Column(JsonDict)
+
+
+class MyUrlModel(db.Model):
+    __tablename__ = 'my_url'
+    id = Column(Integer, primary_key=True)
     url = Column(UrlType)
     url_all_scheme = Column(UrlType(schemes=None))
     url_custom_scheme = Column(UrlType(schemes=('ftp')))
@@ -589,7 +594,7 @@ class TestCoasterModels(unittest.TestCase):
         self.assertRaises(ValueError, MyData, data='NonDict')
 
     def test_urltype(self):
-        m1 = MyData(
+        m1 = MyUrlModel(
             url=u"https://example.com", url_all_scheme=u"magnet://example.com",
             url_custom_scheme=u"ftp://example.com"
             )
@@ -599,8 +604,14 @@ class TestCoasterModels(unittest.TestCase):
         self.assertEqual(m1.url_all_scheme, u"magnet://example.com")
         self.assertEqual(m1.url_custom_scheme, u"ftp://example.com")
 
+    def test_urltype_invalid(self):
+        m1 = MyUrlModel(url=u"example.com")
+        self.session.add(m1)
+        self.session.commit()
+        self.assertEqual(m1.url, u"example.com")
+
     def test_urltype_empty(self):
-        m1 = MyData(url=u"", url_all_scheme=u"", url_custom_scheme=u"")
+        m1 = MyUrlModel(url=u"", url_all_scheme=u"", url_custom_scheme=u"")
         self.session.add(m1)
         self.session.commit()
         self.assertEqual(m1.url, u"")
@@ -609,13 +620,13 @@ class TestCoasterModels(unittest.TestCase):
 
     def test_urltype_invalid_scheme_default(self):
         with self.assertRaises(StatementError):
-            m1 = MyData(url=u"magnet://example.com")
+            m1 = MyUrlModel(url=u"magnet://example.com")
             self.session.add(m1)
             self.session.commit()
 
     def test_urltype_invalid_scheme_custom(self):
         with self.assertRaises(StatementError):
-            m1 = MyData(url_custom_scheme=u"magnet://example.com")
+            m1 = MyUrlModel(url_custom_scheme=u"magnet://example.com")
             self.session.add(m1)
             self.session.commit()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -127,6 +127,8 @@ class MyUrlModel(db.Model):
     url = Column(UrlType)
     url_all_scheme = Column(UrlType(schemes=None))
     url_custom_scheme = Column(UrlType(schemes=('ftp')))
+    url_relative_scheme = Column(UrlType(relative_scheme=True))
+    url_relative_path = Column(UrlType(relative_path=True))
 
 
 class NonUuidKey(BaseMixin, db.Model):
@@ -610,6 +612,12 @@ class TestCoasterModels(unittest.TestCase):
             self.session.add(m1)
             self.session.commit()
 
+    def test_urltype_invalid_without_host(self):
+        with self.assertRaises(StatementError):
+            m2 = MyUrlModel(url=u"https:///test")
+            self.session.add(m2)
+            self.session.commit()
+
     def test_urltype_empty(self):
         m1 = MyUrlModel(url=u"", url_all_scheme=u"", url_custom_scheme=u"")
         self.session.add(m1)
@@ -629,6 +637,25 @@ class TestCoasterModels(unittest.TestCase):
             m1 = MyUrlModel(url_custom_scheme=u"magnet://example.com")
             self.session.add(m1)
             self.session.commit()
+
+    def test_urltype_relative_scheme(self):
+        m1 = MyUrlModel(url_relative_scheme=u"//example.com/test")
+        self.session.add(m1)
+        self.session.commit()
+
+        with self.assertRaises(StatementError):
+            m2 = MyUrlModel(url_relative_scheme=u"example.com/test")
+            self.session.add(m2)
+            self.session.commit()
+
+    def test_urltype_relative_path(self):
+        m1 = MyUrlModel(url_relative_path=u"//example.com/test")
+        self.session.add(m1)
+        self.session.commit()
+
+        m2 = MyUrlModel(url_relative_path=u"example.com/test")
+        self.session.add(m2)
+        self.session.commit()
 
     def test_query(self):
         c1 = Container(name='c1')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -605,10 +605,10 @@ class TestCoasterModels(unittest.TestCase):
         self.assertEqual(m1.url_custom_scheme, u"ftp://example.com")
 
     def test_urltype_invalid(self):
-        m1 = MyUrlModel(url=u"example.com")
-        self.session.add(m1)
-        self.session.commit()
-        self.assertEqual(m1.url, u"example.com")
+        with self.assertRaises(StatementError):
+            m1 = MyUrlModel(url=u"example.com")
+            self.session.add(m1)
+            self.session.commit()
 
     def test_urltype_empty(self):
         m1 = MyUrlModel(url=u"", url_all_scheme=u"", url_custom_scheme=u"")


### PR DESCRIPTION
This `UrlType` is based on [`URLType` from SQLAlchemy-Utils](https://sqlalchemy-utils.readthedocs.io/en/latest/data_types.html#module-sqlalchemy_utils.types.url). Except it takes a `schemes` param.