### PR TITLE
Always use UTC timezone with PostgreSQL

### DIFF
--- a/coaster/db.py
+++ b/coaster/db.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 from flask_sqlalchemy import SQLAlchemy
 
 from sqlalchemy import event

--- a/coaster/db.py
+++ b/coaster/db.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from flask_sqlalchemy import SQLAlchemy
 
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlite3 import Connection as SQLite3Connection
+from psycopg2.extensions import connection as PostgresConnection
 try:
     # PySqlite is only available for Python 2.x
     import pysqlite2.dbapi2
@@ -26,4 +27,13 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
     if isinstance(dbapi_connection, (SQLite3Connection, PySQLite3Connection)):  # pragma: no cover
         cursor = dbapi_connection.cursor()
         cursor.execute('PRAGMA foreign_keys=ON;')
+        cursor.close()
+
+
+# Always use UTC timezone on PostgreSQL
+@event.listens_for(Engine, 'connect')
+def _set_postgresql_timezone(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, PostgresConnection):  # pragma: no cover
+        cursor = dbapi_connection.cursor()
+        cursor.execute("SET TIME ZONE 'UTC';")
         cursor.close()

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requires = [
     'Flask-SQLAlchemy',
     'sqlalchemy-utils',
     'SQLAlchemy>=1.0.9',
+    'psycopg2',
     'docflow>=0.3.2',
     'html2text',
     'bcrypt',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
 pytest
 coverage
 coveralls
-psycopg2


### PR DESCRIPTION
PostgreSQL and SQLAlchemy exhibit timezone calculation errors when using naive timestamps and non-UTC timezones. This patch tells PostgreSQL to always use UTC.