### PR TITLE
LazyRoleSet, role grants, and initial tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@
   longer a hack to be embarrassed by.
 * New: Unicode whitespace strippers, ``ulstrip``, ``urstrip`` and ``ustrip``
 * Added lazy role grant evaluation and declarative role grants
+* New: ``nary_op`` decorator to turn a binary operator into a chained n-ary
+  operator
 
 
 0.6.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@
 * Changed: Markdown parser has moved to ``coaster.utils.markdown`` and is no
   longer a hack to be embarrassed by.
 * New: Unicode whitespace strippers, ``ulstrip``, ``urstrip`` and ``ustrip``
+* Added lazy role grant evaluation and declarative role grants
 
 
 0.6.0

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -136,7 +136,7 @@ from sqlalchemy.orm.collections import (
 )
 from sqlalchemy.orm.dynamic import AppenderMixin
 
-from ..auth import current_auth, add_auth_attribute
+from ..auth import add_auth_attribute, current_auth
 from ..utils import InspectableSet, is_collection, nary_op
 
 __all__ = [

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -160,8 +160,6 @@ def _actor_in_relationship(actor, relationship):
         return True
     elif isinstance(relationship, (AppenderMixin, collections.Container)):
         return actor in relationship
-    elif callable(relationship):
-        return relationship(actor)
     return False
 
 

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -564,6 +564,13 @@ class RoleMixin(object):
             {% if obj.current_roles.editor %}...{% endif %}
 
         This property is also available in :class:`RoleAccessProxy`.
+
+        .. warning::
+            `current_roles` maintains a cache for efficient use in a template where
+            it may be consulted multiple times. It is therefore not safe to use
+            before *and* after code that modifies role assignment. Use
+            :meth:`roles_for` instead, or use `current_roles` only after roles are
+            changed.
         """
         cache = getattr(_request_ctx_stack.top, '_role_cache', None)
         if cache is None:

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -51,10 +51,10 @@ Example use::
     class RoleModel(ColumnMixin, RoleMixin, db.Model):
         __tablename__ = 'role_model'
 
-        # The low level approach is to declare roles in advance.
+        # The low level approach is to declare roles all at once.
         # 'all' is a special role that is always granted from the base class.
-        # Avoid this approach in a parent class because you may accidentally
-        # lose roles if a subclass does not copy `__roles__` from the parent.
+        # Avoid this approach in a parent or mixin class as definitions will
+        # be lost if the subclass does not copy `__roles__`.
 
         __roles__ = {
             'all': {
@@ -65,8 +65,9 @@ Example use::
             },
         }
 
-        # Recommended: annotate roles on the attributes using `with_roles`.
-        # These annotations always add to anything specified in `__roles__`.
+        # Recommended for parent and mixin classes: annotate roles on the attributes
+        # using `with_roles`. These annotations are added to `__roles__` when
+        # SQLAlchemy configures mappers.
 
         id = db.Column(db.Integer, primary_key=True)
         name = with_roles(db.Column(db.Unicode(250)),
@@ -109,10 +110,10 @@ Example use::
 
         def roles_for(self, actor=None, anchors=()):
             # Calling super gives us a LazyRoleSet with the standard roles
-            # and with lazy evaluation of the `owner` role (from `granted_by`)
+            # and with lazy evaluation of of other roles from `granted_by`
             roles = super(RoleModel, self).roles_for(actor, anchors)
 
-            # We can manually add an `owner` role to turn off lazy evaluation
+            # We can manually add a role to override lazy evaluation
             if 'owner-secret' in anchors:
                 roles.add('owner')
             return roles

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -136,7 +136,9 @@ from sqlalchemy.orm.collections import (
 )
 from sqlalchemy.orm.dynamic import AppenderMixin
 
-from ..auth import add_auth_attribute, current_auth
+from flask import _request_ctx_stack
+
+from ..auth import current_auth
 from ..utils import InspectableSet, is_collection, nary_op
 
 __all__ = [
@@ -558,10 +560,10 @@ class RoleMixin(object):
 
         This property is also available in :class:`RoleAccessProxy`.
         """
-        cache = getattr(current_auth, 'role_cache', None)
+        cache = getattr(_request_ctx_stack.top, '_role_cache', None)
         if cache is None:
             cache = {}
-            add_auth_attribute('role_cache', cache)
+            setattr(_request_ctx_stack.top, '_role_cache', cache)
         cache_key = (self, current_auth.actor, current_auth.anchors)
         if cache_key not in cache:
             cache[cache_key] = InspectableSet(

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -167,11 +167,12 @@ class LazyRoleSet(collections.MutableSet):
     def __repr__(self):  # pragma: no cover
         return 'LazyRoleSet({obj}, {actor})'.format(obj=self.obj, actor=self.actor)
 
+    # This is required by the `MutableSet` base class
     def _from_iterable(self, iterable):
         return LazyRoleSet(self.obj, self.actor, iterable)
 
     def _actor_in_relationship(self, relationship):
-        """Test whether an actor is present in a relationship"""
+        """Test whether the bound actor is present in a relationship"""
         attr = getattr(self.obj, relationship)
         if self.actor == attr:
             return True
@@ -180,7 +181,7 @@ class LazyRoleSet(collections.MutableSet):
         return False
 
     def _role_is_present(self, role):
-        """Test whether a role has been granted to the given actor"""
+        """Test whether a role has been granted to the bound actor"""
         if role in self._present:
             return True
         elif role in self._not_present:

--- a/coaster/utils/classes.py
+++ b/coaster/utils/classes.py
@@ -272,7 +272,7 @@ class InspectableSet(Set):
     """
 
     def __init__(self, members=()):
-        if not isinstance(members, set):
+        if not isinstance(members, Set):
             members = set(members)
         object.__setattr__(self, '_members', members)
 

--- a/coaster/utils/misc.py
+++ b/coaster/utils/misc.py
@@ -12,6 +12,7 @@ import six
 from base64 import b64decode, b64encode, urlsafe_b64decode, urlsafe_b64encode
 from datetime import datetime
 from email.header import decode_header
+from functools import wraps
 from random import SystemRandom
 import binascii
 import collections
@@ -36,6 +37,7 @@ __all__ = [
     'newpin',
     'make_name',
     'make_password',
+    'nary_op',
     'check_password',
     'format_currency',
     'md5sum',
@@ -760,3 +762,19 @@ def domain_namespace_match(domain, namespace):
     True
     """
     return base_domain_matches(domain, ".".join(namespace.split(".")[::-1]))
+
+
+def nary_op(f, doc=None):
+    """
+    Decorator to convert a binary operator into a chained n-ary operator.
+    """
+
+    @wraps(f)
+    def inner(lhs, *others):
+        for other in others:
+            lhs = f(lhs, other)
+        return lhs
+
+    if doc is not None:
+        inner.__doc__ = doc
+    return inner

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,9 @@
 ignore = I100, I201, E501, E124, E128, E124, E203, E402, W503, N805, S101
 exclude = build/lib
 
+[pycodestyle]
+max-line-length = 88
+
 [pydocstyle]
 
 [isort]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,6 @@ from flask_sqlalchemy import SQLAlchemy
 from flask import Flask, _request_ctx_stack, has_request_context
 
 from coaster.auth import (
-    AuthAnchors,
     add_auth_anchor,
     add_auth_attribute,
     current_auth,
@@ -60,36 +59,6 @@ class Client(BaseMixin, db.Model):
 
 
 # --- Tests -------------------------------------------------------------------
-
-
-class TestAuthAnchors(unittest.TestCase):
-    """Tests for the AuthAnchors class"""
-
-    def test_empty(self):
-        """Test the AuthAnchors container"""
-        empty = AuthAnchors()
-        self.assertEqual(len(empty), 0)
-        self.assertFalse(empty)
-        self.assertEqual(empty, set())
-
-    def test_prefilled(self):
-        prefilled = AuthAnchors({1, 2})
-        self.assertEqual(len(prefilled), 2)
-        self.assertTrue(prefilled)
-        self.assertIn(1, prefilled)
-        self.assertIn(2, prefilled)
-        self.assertNotIn(3, prefilled)
-        self.assertEqual(prefilled, {1, 2})
-
-    def test_postfilled(self):
-        postfilled = AuthAnchors()
-        self.assertEqual(len(postfilled), 0)
-        postfilled._add(1)
-        self.assertIn(1, postfilled)
-        self.assertNotIn(2, postfilled)
-        postfilled._add(2)
-        self.assertIn(2, postfilled)
-        self.assertEqual(postfilled, {1, 2})
 
 
 class TestCurrentUserNoRequest(unittest.TestCase):

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -506,6 +506,31 @@ class TestCoasterRoles(unittest.TestCase):
         assert 'creator' not in ro2u1
         assert 'creator' in ro2u2
 
+    def test_actors_with(self):
+        m1 = RoleGrantMany()
+        m2 = RoleGrantMany()
+        u1 = RoleUser(doc=m1)
+        u2 = RoleUser(doc=m2)
+        o1 = RoleGrantOne(user=u1)
+        o2 = RoleGrantOne(user=u2)
+        m1.secondary_users.extend([u1, u2])
+
+        assert o1.actors_with({'creator'}) == {u1}
+        assert o2.actors_with({'creator'}) == {u2}
+
+        assert m1.actors_with({'primary_role'}) == {u1}
+        assert m2.actors_with({'primary_role'}) == {u2}
+        assert m1.actors_with({'secondary_role'}) == {u1, u2}
+        assert m2.actors_with({'secondary_role'}) == set()
+        assert m1.actors_with({'primary_role', 'secondary_role'}) == {u1, u2}
+        assert m2.actors_with({'primary_role', 'secondary_role'}) == {u2}
+
+    def test_actors_with_invalid(self):
+        m1 = RoleGrantMany()
+        with self.assertRaises(ValueError):
+            # Parameter can't be a string
+            m1.actors_with('owner')
+
 
 class TestLazyRoleSet(unittest.TestCase):
     """Tests for LazyRoleSet, isolated from RoleMixin"""

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -542,10 +542,7 @@ class TestLazyRoleSet(unittest.TestCase):
     class Document(RoleMixin):
         _user = None
         _userlist = ()
-        __roles__ = {
-            'owner': {'granted_by': ['user', 'userlist']},
-            'any_role': {'granted_by': ['user_in_any']},
-        }
+        __roles__ = {'owner': {'granted_by': ['user', 'userlist']}}
 
         # Test flags
         accessed_user = False
@@ -570,9 +567,6 @@ class TestLazyRoleSet(unittest.TestCase):
         def userlist(self, value):
             self._userlist = value
             self.accessed_userlist = False
-
-        def user_in_any(self, user):
-            return user is not None and (user == self.user or user in self.userlist)
 
     class User(object):
         pass
@@ -701,16 +695,6 @@ class TestLazyRoleSet(unittest.TestCase):
 
         # We know it's via 'userlist' because the flag is set. Further,
         # 'user' was also examined because it has prority (`granted_by` is ordered)
-        assert d.accessed_user is True
-        assert d.accessed_userlist is True
-
-        # Finally, confirm callable relationships are accessed
-        d.user = None
-        d.userlist = [u2]
-        assert d.accessed_user is False
-        assert d.accessed_userlist is False
-        assert 'any_role' not in d.roles_for(u1)
-        assert 'any_role' in d.roles_for(u2)
         assert d.accessed_user is True
         assert d.accessed_userlist is True
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -517,7 +517,10 @@ class TestLazyRoleSet(unittest.TestCase):
     class Document(RoleMixin):
         _user = None
         _userlist = ()
-        __roles__ = {'owner': {'granted_by': ['user', 'userlist']}}
+        __roles__ = {
+            'owner': {'granted_by': ['user', 'userlist']},
+            'any_role': {'granted_by': ['user_in_any']},
+        }
 
         # Test flags
         accessed_user = False
@@ -542,6 +545,9 @@ class TestLazyRoleSet(unittest.TestCase):
         def userlist(self, value):
             self._userlist = value
             self.accessed_userlist = False
+
+        def user_in_any(self, user):
+            return user is not None and (user == self.user or user in self.userlist)
 
     class User(object):
         pass
@@ -670,6 +676,16 @@ class TestLazyRoleSet(unittest.TestCase):
 
         # We know it's via 'userlist' because the flag is set. Further,
         # 'user' was also examined because it has prority (`granted_by` is ordered)
+        assert d.accessed_user is True
+        assert d.accessed_userlist is True
+
+        # Finally, confirm callable relationships are accessed
+        d.user = None
+        d.userlist = [u2]
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+        assert 'any_role' not in d.roles_for(u1)
+        assert 'any_role' in d.roles_for(u2)
         assert d.accessed_user is True
         assert d.accessed_userlist is True
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -16,12 +16,14 @@ from coaster.db import db
 from coaster.sqlalchemy import (
     BaseMixin,
     BaseNameMixin,
+    LazyRoleSet,
     RoleAccessProxy,
     RoleMixin,
     UuidMixin,
     declared_attr_roles,
     with_roles,
 )
+from coaster.utils import InspectableSet
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
@@ -86,11 +88,11 @@ class RoleModel(DeclaredAttrMixin, RoleMixin, db.Model):
     # (an iterable). The format for anchors is not specified by RoleMixin.
 
     def roles_for(self, actor=None, anchors=()):
-        # Calling super give us a result set with the standard roles
-        result = super(RoleModel, self).roles_for(actor, anchors)
+        # Calling super gives us a set with the standard roles
+        roles = super(RoleModel, self).roles_for(actor, anchors)
         if 'owner-secret' in anchors:
-            result.add('owner')  # Grant owner role
-        return result
+            roles.add('owner')  # Grant owner role
+        return roles
 
 
 class AutoRoleModel(RoleMixin, db.Model):
@@ -146,6 +148,10 @@ class RelationshipParent(BaseNameMixin, db.Model):
             }
         }
     }
+
+
+class GrantedRoles(BaseMixin, db.Model):
+    __tablename__ = 'granted_roles'
 
 
 # --- Tests -------------------------------------------------------------------
@@ -419,3 +425,199 @@ class TestCoasterRoles(unittest.TestCase):
         assert isinstance(proxy.children_dict_column, dict)
         assert isinstance(proxy.children_dict_column['child'], RoleAccessProxy)
         assert proxy.children_dict_column['child'].title == child.title
+
+
+class TestLazyRoleSet(unittest.TestCase):
+    """Tests for LazyRoleSet, isolated from RoleMixin"""
+
+    class EmptyDocument(RoleMixin):
+        pass
+
+    class Document(RoleMixin):
+        _user = None
+        _userlist = ()
+        __roles__ = {'owner': {'granted_by': ['user', 'userlist']}}
+
+        # Test flags
+        accessed_user = False
+        accessed_userlist = False
+
+        @property
+        def user(self):
+            self.accessed_user = True
+            return self._user
+
+        @user.setter
+        def user(self, value):
+            self._user = value
+            self.accessed_user = False
+
+        @property
+        def userlist(self):
+            self.accessed_userlist = True
+            return self._userlist
+
+        @userlist.setter
+        def userlist(self, value):
+            self._userlist = value
+            self.accessed_userlist = False
+
+    class User(object):
+        pass
+
+    def test_initial(self):
+        r1 = LazyRoleSet(self.EmptyDocument(), self.User(), {'all', 'auth'})
+        assert r1._present == {'all', 'auth'}
+        assert r1._not_present == set()
+
+        r2 = LazyRoleSet(self.EmptyDocument(), self.User())
+        assert r2._present == set()
+        assert r2._not_present == set()
+
+    def test_set_add_remove_discard(self):
+        r = LazyRoleSet(self.EmptyDocument(), self.User())
+
+        assert r._present == set()
+        assert r._not_present == set()
+        assert not r
+
+        r.add('role1')
+        assert r._present == {'role1'}
+        assert r._not_present == set()
+        assert r
+
+        r.discard('role1')
+        assert r._present == set()
+        assert r._not_present == {'role1'}
+        assert not r
+
+        r.update({'role2', 'role3'})
+        assert r._present == {'role2', 'role3'}
+        assert r._not_present == {'role1'}
+        assert r
+
+        r.add('role1')
+        assert r._present == {'role1', 'role2', 'role3'}
+        assert r._not_present == set()
+        assert r
+
+        r.remove('role2')
+        assert r._present == {'role1', 'role3'}
+        assert r._not_present == {'role2'}
+        assert r
+
+    def test_set_operations(self):
+        # Confirm we support common set operations
+        doc = self.Document()
+        user = self.User()
+        r = LazyRoleSet(doc, user, {'all', 'auth'})
+        assert r == {'all', 'auth'}
+        assert r == LazyRoleSet(doc, user, {'all', 'auth'})
+        assert r != LazyRoleSet(doc, None, {'all', 'auth'})
+        assert len(r) == 2
+        assert 'all' in r
+        assert 'random' not in r
+        assert r != {'all', 'anon'}
+        assert r.isdisjoint({'random'})
+        assert r.issubset({'all', 'auth', 'owner'})
+        assert r <= {'all', 'auth', 'owner'}
+        assert r < {'all', 'auth', 'owner'}
+        assert not r < {'all', 'auth'}
+        assert r.issuperset({'all'})
+        assert r >= {'all'}
+        assert r > {'all'}
+        assert not r > {'all', 'auth'}
+        assert r.union({'owner'}) == LazyRoleSet(doc, user, {'all', 'auth', 'owner'})
+        assert r | {'owner'} == LazyRoleSet(doc, user, {'all', 'auth', 'owner'})
+        assert r.union({'owner'}) == {'all', 'auth', 'owner'}
+        assert r | {'owner'} == {'all', 'auth', 'owner'}
+        assert r.intersection({'all'}) == LazyRoleSet(doc, user, {'all'})
+        assert r & {'all'} == LazyRoleSet(doc, user, {'all'})
+        assert r.intersection({'all'}) == {'all'}
+        assert r & {'all'} == {'all'}
+
+        r2 = r.copy()
+        assert r is not r2
+        assert r2 is not r
+        assert r == r2
+        assert r2 == r
+
+    def test_lazyroleset(self):
+        d = self.Document()
+        u1 = self.User()
+        u2 = self.User()
+        d.user = u1
+
+        # At the start, the access flags are false
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+
+        # Standard roles work
+        assert 'all' in d.roles_for(u1)
+        assert 'all' in d.roles_for(u2)
+
+        # 'owner' relationships are untouched when testing for standard roles
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+
+        # The 'owner' role is granted for the user present in d.user
+        assert 'owner' in d.roles_for(u1)
+
+        # Confirm which relationship was examined
+        assert d.accessed_user is True
+        assert d.accessed_userlist is False
+
+        # The 'owner' role is not granted for a user not present in
+        # both relationships.
+        assert 'owner' not in d.roles_for(u2)
+
+        # Both relationships have been examined this time
+        assert d.accessed_user is True
+        assert d.accessed_userlist is True
+
+        # Now test the other relationship for granting a role
+        d.user = None
+        d.userlist = [u2]
+
+        # Confirm flags were reset
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+
+        # The 'owner' role is granted for the user present in d.userlist
+        assert 'owner' not in d.roles_for(u1)
+        assert 'owner' in d.roles_for(u2)
+
+        # We know it's via 'userlist' because the flag is set. Further,
+        # 'user' was also examined because it has prority (`granted_by` is ordered)
+        assert d.accessed_user is True
+        assert d.accessed_userlist is True
+
+    def test_inspectable_lazyroleset(self):
+        d = self.Document()
+        u1 = self.User()
+        u2 = self.User()
+        d.user = u1
+
+        # At the start, the access flags are false
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+
+        # Constructing an inspectable set does not enumerate roles
+        r1 = InspectableSet(d.roles_for(u1))
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+
+        # However, accessing the role does
+        assert r1.owner is True
+        assert d.accessed_user is True
+        assert d.accessed_userlist is False
+
+        # Reset and try the other relationship
+        d.user = None
+        d.userlist = [u2]
+        r2 = InspectableSet(d.roles_for(u2))
+        assert d.accessed_user is False
+        assert d.accessed_userlist is False
+        assert r2.owner is True
+        assert d.accessed_user is True
+        assert d.accessed_userlist is True


### PR DESCRIPTION
This PR removes the need for models to provide `roles_for` methods. Instead, roles are discovered automatically from relationships as declared in `__roles__` so:

```python
__roles__ = {
    'owner': {
        'granted_by': ['user', 'admins'],
    },
}
```

Calling `obj.roles_for(user)` will now return a `LazyRoleSet` which initially does not contain any roles (other than the standard set of `all` and `auth` or `anon`). A test such as `'owner' in obj.roles_for(current_auth.user)` or `obj.current_roles.owner` will trigger the actual lookup, wherein the lazy role set will evaluate if the given actor is present in the object's `user` and `admins` attributes, in order (from the example above).

Scalar, collection-type and query-type (dynamic) relationships are all supported, but not dict-type relationships, as those don't offer clarity on whether the actor is in the keys or the values. Callable methods are also supported and assumed to take a single parameter with the actor.

In addition to `__roles__`, relationships that grant roles can also be annotated with `with_roles(relationship, grants={roles})`. However, this removes control over the order in which relationships are inspected, and so is not recommended for roles that have some relationships that are expensive to lookup.

Finally, reverse lookup to discover users from roles is also possible using the `actors_with` method. This one consults all listed relationships, skipping over callables, and returns a set of users.

Support for callables in role discovery should be considered experimental as it is not bidirectional. It may be removed in future.