### PR TITLE
Data verification properties for CoordinatesMixin

### DIFF
--- a/coaster/sqlalchemy/mixins.py
+++ b/coaster/sqlalchemy/mixins.py
@@ -974,7 +974,18 @@ class CoordinatesMixin(object):
     longitude = Column(Numeric)
 
     @property
+    def has_coordinates(self):
+        """Return `True` if both latitude and longitude are present."""
+        return self.latitude is not None and self.longitude is not None
+
+    @property
+    def has_missing_coordinates(self):
+        """Return `True` if one or both of latitude and longitude are missing."""
+        return self.latitude is None or self.longitude is None
+
+    @property
     def coordinates(self):
+        """Tuple of (latitude, longitude)."""
         return self.latitude, self.longitude
 
     @coordinates.setter

--- a/tests/test_sqlalchemy_coordinates.py
+++ b/tests/test_sqlalchemy_coordinates.py
@@ -3,14 +3,11 @@
 from __future__ import absolute_import
 
 import unittest
-import warnings
-
-import sqlalchemy.exc
 
 from coaster.db import db
 from coaster.sqlalchemy import BaseMixin, CoordinatesMixin
 
-from .test_models import app1, app2
+from .test_models import app2
 
 
 class CoordinatesData(BaseMixin, CoordinatesMixin, db.Model):
@@ -21,7 +18,8 @@ class CoordinatesData(BaseMixin, CoordinatesMixin, db.Model):
 
 
 class TestCoordinatesColumn(unittest.TestCase):
-    app = app1
+    # Restrict tests to PostgreSQL as SQLite3 doesn't have a Decimal type
+    app = app2
 
     def setUp(self):
         self.ctx = self.app.test_request_context()
@@ -41,22 +39,30 @@ class TestCoordinatesColumn(unittest.TestCase):
 
     def test_columns_when_null(self):
         data = CoordinatesData()
-        self.assertEqual(data.coordinates, (None, None))
+        assert data.coordinates == (None, None)
+        assert data.has_coordinates is False
+
+    def test_columns_when_missing(self):
+        data = CoordinatesData()
+        assert data.has_coordinates is False
+        assert data.has_missing_coordinates is True
+        data.coordinates = (12, None)
+        assert data.has_coordinates is False
+        assert data.has_missing_coordinates is True
+        data.coordinates = (None, 73)
+        assert data.has_coordinates is False
+        assert data.has_missing_coordinates is True
+        data.coordinates = (12, 73)
+        assert data.has_coordinates is True
+        assert data.has_missing_coordinates is False
 
     def test_column_set_value(self):
-        warnings.simplefilter('ignore', category=sqlalchemy.exc.SAWarning)
-
         data = CoordinatesData()
         data.coordinates = (12, 73)
-        self.assertEqual(data.coordinates, (12, 73))
+        assert data.coordinates == (12, 73)
+        assert data.has_coordinates is True
         db.session.add(data)
         db.session.commit()
 
         readdata = CoordinatesData.query.first()
-        self.assertEqual(readdata.coordinates, (12, 73))
-
-        warnings.resetwarnings()
-
-
-class TestCoordinatesColumn2(TestCoordinatesColumn):
-    app = app2
+        assert readdata.coordinates == (12, 73)


### PR DESCRIPTION
The `has_coordinates` property makes it easier to verify if a location has coordinates for displaying on a map.