### PR TITLE
production should be the default environment

### DIFF
--- a/coaster/app.py
+++ b/coaster/app.py
@@ -117,11 +117,9 @@ def init_app(app):
     # Load additional settings from the app's environment-specific config file:
     # Flask sets ``ENV`` configuration variable based on ``FLASK_ENV`` environment
     # variable. So we can directly get it from ``app.config['ENV']``.
+    # Lowercase because that's how flask defines it.
     # ref: https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features
-    env = app.config.get('ENV', 'production')
-    additional = _additional_config.get(
-        env.lower()
-    )  # Lowercase because that's how we define it
+    additional = _additional_config.get(app.config['ENV'].lower())
     if additional:
         load_config_from_file(app, additional)
 

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -119,7 +119,7 @@ def init_app(app, env=None):
     # Load additional settings from the app's environment-specific config file
     if not env:
         env = environ.get(
-            'FLASK_ENV', 'production'
+            'FLASK_ENV', app.config.get('ENV', 'production')
         )
     additional = _additional_config.get(
         env.lower()

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -86,7 +86,7 @@ class SandboxedFlask(Flask):
         return rv
 
 
-def init_app(app, env=None):
+def init_app(app):
     """
     Configure an app depending on the environment. Loads settings from a file
     named ``settings.py`` in the instance folder, followed by additional
@@ -103,9 +103,6 @@ def init_app(app, env=None):
     :func:`coaster.logger.init_app`.
 
     :param app: App to be configured
-    :param env: Environment to configure for (``'development'``,
-        ``'production'`` or ``'testing'``). If not specified, the ``FLASK_ENV``
-        environment variable is consulted. Defaults to ``'production'``.
     """
     # Make current_auth available to app templates
     app.jinja_env.globals['current_auth'] = current_auth
@@ -116,12 +113,12 @@ def init_app(app, env=None):
     app.config.setdefault('SQLALCHEMY_TRACK_MODIFICATIONS', False)
     # Load config from the app's settings.py
     load_config_from_file(app, 'settings.py')
-    # Load additional settings from the app's environment-specific config file
-    if not env:
-        # Flask sets ``ENV`` configuration variable based on ``FLASK_ENV`` environment
-        # variable. So we can directly get it from ``app.config['ENV']``.
-        # ref: https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features
-        env = app.config.get('ENV', 'production')
+
+    # Load additional settings from the app's environment-specific config file:
+    # Flask sets ``ENV`` configuration variable based on ``FLASK_ENV`` environment
+    # variable. So we can directly get it from ``app.config['ENV']``.
+    # ref: https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features
+    env = app.config.get('ENV', 'production')
     additional = _additional_config.get(
         env.lower()
     )  # Lowercase because that's how we define it

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -105,7 +105,7 @@ def init_app(app, env=None):
     :param app: App to be configured
     :param env: Environment to configure for (``'development'``,
         ``'production'`` or ``'testing'``). If not specified, the ``FLASK_ENV``
-        environment variable is consulted. Defaults to ``'development'``.
+        environment variable is consulted. Defaults to ``'production'``.
     """
     # Make current_auth available to app templates
     app.jinja_env.globals['current_auth'] = current_auth
@@ -119,7 +119,7 @@ def init_app(app, env=None):
     # Load additional settings from the app's environment-specific config file
     if not env:
         env = environ.get(
-            'FLASK_ENV', 'DEVELOPMENT'
+            'FLASK_ENV', 'production'
         )  # Uppercase for compatibility with Flask-Environments
     additional = _additional_config.get(
         env.lower()

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -7,7 +7,6 @@ App configuration
 
 from __future__ import absolute_import, print_function
 
-from os import environ
 import sys
 
 from flask import Flask, g, get_flashed_messages, request, session, url_for

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -120,7 +120,7 @@ def init_app(app, env=None):
     if not env:
         env = environ.get(
             'FLASK_ENV', 'production'
-        )  # Uppercase for compatibility with Flask-Environments
+        )
     additional = _additional_config.get(
         env.lower()
     )  # Lowercase because that's how we define it

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -118,9 +118,10 @@ def init_app(app, env=None):
     load_config_from_file(app, 'settings.py')
     # Load additional settings from the app's environment-specific config file
     if not env:
-        env = environ.get(
-            'FLASK_ENV', app.config.get('ENV', 'production')
-        )
+        # Flask sets ``ENV`` configuration variable based on ``FLASK_ENV`` environment
+        # variable. So we can directly get it from ``app.config['ENV']``.
+        # ref: https://flask.palletsprojects.com/en/1.1.x/config/#environment-and-debug-features
+        env = app.config.get('ENV', 'production')
     additional = _additional_config.get(
         env.lower()
     )  # Lowercase because that's how we define it

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ PY2 = sys.version_info[0] == 2
 requires = [
     'six>=1.13.0',
     'nltk>=3.0',
-    'shortuuid',
+    'shortuuid==0.5.0',
     'isoweek',
     'UgliPyJS',
     'PyExecJS',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,8 +34,8 @@ class TestCoasterUtils(unittest.TestCase):
             self.assertEqual(_additional_config.get(environ[env]), v)
 
     def test_init_app(self):
-        env = "testing"
-        init_app(self.app, env)
+        environ['FLASK_ENV'] = "testing"
+        init_app(self.app)
         self.assertEqual(self.app.config['SETTINGS_KEY'], "settings")
         self.assertEqual(self.app.config['TEST_KEY'], "test")
 
@@ -55,8 +55,8 @@ class TestCoasterUtils(unittest.TestCase):
         self.assertFalse(load_config_from_file(app, "notfound.py"))
 
     def test_current_auth(self):
-        env = "testing"
-        init_app(self.app, env)
+        environ['FLASK_ENV'] = "testing"
+        init_app(self.app)
         with self.app.test_request_context():
             self.assertEqual(
                 render_template_string(


### PR DESCRIPTION
Flask sets production as the default environment. Coaster should also do so.