### PR TITLE
Replaced old iso8601 lib with aniso8601

### DIFF
--- a/coaster/utils/datetime.py
+++ b/coaster/utils/datetime.py
@@ -10,13 +10,15 @@ import six
 
 from datetime import datetime
 
-from iso8601 import ParseError, parse_date
+from aniso8601 import parse_datetime, parse_duration
+from aniso8601.exceptions import ISOFormatError as ParseError
 import isoweek
 import pytz
 
 __all__ = [
     'utcnow',
     'parse_isoformat',
+    'parse_duration',
     'isoweek_datetime',
     'midnight_to_utc',
     'sorted_timezones',
@@ -48,12 +50,12 @@ def parse_isoformat(text, naive=True):
     """
     if naive:
         return (
-            parse_date(text, default_timezone=pytz.UTC)
+            parse_datetime(text)
             .astimezone(pytz.UTC)
             .replace(tzinfo=None)
         )
     else:
-        return parse_date(text, default_timezone=pytz.UTC)
+        return parse_datetime(text)
 
 
 def isoweek_datetime(year, week, timezone='UTC', naive=False):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requires = [
     'html2text==2019.8.11;python_version=="2.7"',
     'html2text>2019.8.11;python_version>="3.6"',
     'html5lib>=0.999999999',
-    'iso8601',
+    'aniso8601',
     'isoweek',
     'Jinja2<=2.11.1;python_version=="2.7"',
     'Jinja2>=2.11.1;python_version>="3.6"',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,8 +20,8 @@ from coaster.utils import (
     midnight_to_utc,
     namespace_from_url,
     nary_op,
-    parse_isoformat,
     parse_duration,
+    parse_isoformat,
     require_one_of,
     sanitize_html,
     sorted_timezones,
@@ -120,7 +120,9 @@ class TestCoasterUtils(unittest.TestCase):
             parse_isoformat('2019-05-03T05:02:26.340937Z\'', naive=False)
 
     def test_parse_duration(self):
-        assert parse_duration('P1Y2M3DT4H54M6S') == datetime.timedelta(days=428, seconds=17646)
+        assert parse_duration('P1Y2M3DT4H54M6S') == datetime.timedelta(
+            days=428, seconds=17646
+        )
         assert parse_duration('PT10M1S') == datetime.timedelta(seconds=601)
         assert parse_duration('PT1H1S') == datetime.timedelta(seconds=3601)
         with self.assertRaises(ParseError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from coaster.utils import (
     namespace_from_url,
     nary_op,
     parse_isoformat,
+    parse_duration,
     require_one_of,
     sanitize_html,
     sorted_timezones,
@@ -117,6 +118,14 @@ class TestCoasterUtils(unittest.TestCase):
 
         with self.assertRaises(ParseError):
             parse_isoformat('2019-05-03T05:02:26.340937Z\'', naive=False)
+
+    def test_parse_duration(self):
+        assert parse_duration('P1Y2M3DT4H54M6S') == datetime.timedelta(days=428, seconds=17646)
+        assert parse_duration('PT10M1S') == datetime.timedelta(seconds=601)
+        assert parse_duration('PT1H1S') == datetime.timedelta(seconds=3601)
+        with self.assertRaises(ParseError):
+            # no time separator
+            assert parse_duration('P2M10M1S')
 
     def test_sanitize_html(self):
         html = """<html><head><title>Test sanitize_html</title><script src="jquery.js"></script></head><body><!-- Body Comment-->Body<script type="application/x-some-script">alert("foo");</script></body></html>"""


### PR DESCRIPTION
YouTube's API returns video duration in ISO8601 format: https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm

Hence adding the parser for it in coaster