### PR TITLE
Turn short_title into a property

### DIFF
--- a/coaster/sqlalchemy/mixins.py
+++ b/coaster/sqlalchemy/mixins.py
@@ -770,6 +770,7 @@ class BaseScopedNameMixin(BaseMixin):
                     )
                 )
 
+    @property
     def short_title(self):
         """
         Generates an abbreviated title by subtracting the parent's title from this
@@ -793,7 +794,7 @@ class BaseScopedNameMixin(BaseMixin):
     @property
     def title_for_name(self):
         """The version of the title used for :meth:`make_name`"""
-        return self.short_title()
+        return self.short_title
 
     def permissions(self, actor, inherited=None):
         """

--- a/tests/test_sqlalchemy_models.py
+++ b/tests/test_sqlalchemy_models.py
@@ -504,17 +504,17 @@ class TestCoasterModels(unittest.TestCase):
         c1 = self.make_container()
         self.session.commit()
         d1 = ScopedNamedDocument(title="Hello", content="World", container=c1)
-        self.assertEqual(d1.short_title(), "Hello")
+        self.assertEqual(d1.short_title, "Hello")
 
         c1.title = "Container"
         d1.title = "Container Contained"
-        self.assertEqual(d1.short_title(), "Contained")
+        self.assertEqual(d1.short_title, "Contained")
 
         d1.title = "Container: Contained"
-        self.assertEqual(d1.short_title(), "Contained")
+        self.assertEqual(d1.short_title, "Contained")
 
         d1.title = "Container - Contained"
-        self.assertEqual(d1.short_title(), "Contained")
+        self.assertEqual(d1.short_title, "Contained")
 
     def test_id_named(self):
         """Documents with a global id in the URL"""


### PR DESCRIPTION
Needs to be a property for casting into JSON via RoleAccessProxy. This is a breaking change requiring updates in all apps that use short_title