### PR TITLE
Partial Flask 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 # command to install dependencies
 install:
   - pip install pre-commit
+  - pip install 'idna<3'
   - python setup.py install
   - pip install -r test_requirements.txt
 # command to prepare environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 cache: pip
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 services:
   - postgresql
 # command to install dependencies

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -4,7 +4,6 @@ App configuration
 """
 
 from flask import Flask, g, get_flashed_messages, request, session, url_for
-from flask.json import tojson_filter as _tojson_filter
 from flask.sessions import SecureCookieSessionInterface
 import itsdangerous
 
@@ -134,7 +133,6 @@ class SandboxedFlask(Flask):
             session=session,
             g=g,  # FIXME: Similarly with g: no access for sandboxed templates
         )
-        rv.filters['tojson'] = _tojson_filter
         return rv
 
 

--- a/coaster/manage.py
+++ b/coaster/manage.py
@@ -30,11 +30,16 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 from alembic.util import CommandError
 
-from flask_migrate import MigrateCommand
 import flask
 
 from flask_script import Manager, Shell, prompt_bool
 from flask_script.commands import Clean, ShowUrls
+
+try:
+    from flask_migrate import MigrateCommand
+except ImportError:
+    # No longer supported in Flask-Migrate 3.0; use `flask db` instead
+    MigrateCommand = None
 
 manager = Manager()
 
@@ -112,7 +117,8 @@ def init_manager(app, db, **kwargs):
     manager.app = app
     manager.db = db
     manager.context = kwargs
-    manager.add_command('db', MigrateCommand)
+    if MigrateCommand is not None:
+        manager.add_command('db', MigrateCommand)
     manager.add_command('clean', Clean())
     manager.add_command('showurls', ShowUrls())
     manager.add_command('shell', Shell(make_context=shell_context))

--- a/coaster/sqlalchemy/statemanager.py
+++ b/coaster/sqlalchemy/statemanager.py
@@ -659,7 +659,7 @@ class StateTransitionWrapper:
                 self.obj, transition=self.statetransition, exception=e
             )
             return e.args[0]
-        except Exception as e:
+        except Exception as e:  # NOQA: B902
             transition_exception.send(
                 self.obj, transition=self.statetransition, exception=e
             )

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Removed in pallets/flask#3895, and we were not using it anyway. `SandboxedFlask` was only used in Eventframe (introduced 2012, discontinued 2017-18, shutdown 2020).