### PR TITLE
Unnecessary `else` / `elif` used after `return`

### DIFF
--- a/coaster/views/misc.py
+++ b/coaster/views/misc.py
@@ -60,8 +60,7 @@ def get_current_url():
     query = request.query_string
     if query:
         return url + '?' + query.decode()
-    else:
-        return url
+    return url
 
 
 __marker = object()


### PR DESCRIPTION
The use of else or elif becomes redundant and can be dropped if the last statement under the leading if / elif block is a return statement.