### PR TITLE
Patch _clean_external_url

### DIFF
--- a/coaster/views/misc.py
+++ b/coaster/views/misc.py
@@ -29,7 +29,7 @@ def _index_url():
 
 
 def _clean_external_url(url):
-    if url.lower.startswith(('http://', 'https://', '//')):
+    if url.lower().startswith(('http://', 'https://', '//')):
         # Do the domains and ports match?
         pnext = urlsplit(url)
         preq = urlsplit(request.url)

--- a/coaster/views/misc.py
+++ b/coaster/views/misc.py
@@ -29,7 +29,7 @@ def _index_url():
 
 
 def _clean_external_url(url):
-    if url.startswith(('http://', 'https://', '//')):
+    if url.lower.startswith(('http://', 'https://', '//')):
         # Do the domains and ports match?
         pnext = urlsplit(url)
         preq = urlsplit(request.url)


### PR DESCRIPTION
The function `_clean_external_url` doesn't currently normalize (i.e., convert to lowercase) the scheme section of the URL. This creates a situation where the function's check for external host names can be bypassed, making the service vulnerable to open redirection attacks. This pull request has a fix for the ` _clean_external_url` function.