### PR TITLE
Improved current_auth and other fixes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,8 +17,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.10', '3.7']
+        python-version: ['3.7', '3.10']
 
     services:
       redis:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.10', '3.7']
 
     services:
       redis:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,85 @@
+name: Pytest
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+    paths:
+      - '**.py'
+      - '**.js'
+      - '**.jinja2'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.10']
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install project
+        run: |
+          python setup.py develop
+      - name: Install pytest-github-actions-annotate-failures
+        run: pip install pytest-github-actions-annotate-failures
+      - name: Create PostgreSQL databases
+        run: |
+          sudo apt-get install postgresql-client -y
+          psql -h localhost -U postgres -c "create user $(whoami);"
+          psql -h localhost -U postgres -c "create database coaster_test;"
+          psql -h localhost -U postgres -c "grant all privileges on database coaster_test to $(whoami);"
+      - name: Test with pytest
+        run: |
+          pytest --showlocals --cov=coaster
+      - name: Prepare coverage report
+        run: |
+          mkdir -p coverage
+          coverage lcov -o coverage/coaster.lcov
+      - name: Upload coverage report to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: ./coverage/coaster.lcov
+          flag-name: python-${{ matrix.python-version }}
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: ./coverage/coaster.lcov
+          parallel-finished: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,7 +61,7 @@ jobs:
           psql -h localhost -U postgres -c "grant all privileges on database coaster_test to $(whoami);"
       - name: Test with pytest
         run: |
-          pytest --showlocals --cov=coaster
+          pytest --ignore-flaky --showlocals --cov=coaster
       - name: Prepare coverage report
         run: |
           mkdir -p coverage

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Install project
         run: |
           python setup.py develop
+          pip install -r test_requirements.txt
       - name: Install pytest-github-actions-annotate-failures
         run: pip install pytest-github-actions-annotate-failures
       - name: Create PostgreSQL databases

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
       - name: Install project
         run: |
           python setup.py develop

--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -1,0 +1,142 @@
+name: Telegram Notify
+on:
+  issues:
+    types: [opened, edited, closed, reopened, milestoned, demilestoned]
+  issue_comment:
+    types: [created]
+  push:
+  pull_request:
+    types:
+      # Exclude 'synchronize' as that is duplicated in the 'push' event
+      [
+        assigned,
+        closed,
+        converted_to_draft,
+        edited,
+        labeled,
+        locked,
+        opened,
+        ready_for_review,
+        reopened,
+        review_request_removed,
+        review_requested,
+        unassigned,
+        unlabeled,
+        unlocked,
+      ]
+  pull_request_review:
+  project:
+  project_card:
+    types: [created, moved, converted, edited, deleted]
+  release:
+  watch:
+
+jobs:
+  tguser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kanga333/variable-mapper@master
+        with:
+          key: '${{ github.actor }}'
+          map: |
+            {
+              "djamg": {"tguser": "@dj_amg"},
+              "jace": {"tguser": "@jackerhack"},
+              "miteshashar": {"tguser": "@miteshashar"},
+              "sankarshanmukhopadhyay": {"tguser": "@sankarshan"},
+              "StephanieBr": {"tguser": "@stephaniebrne"},
+              "vidya-ram": {"tguser": "@vidya_ramki"},
+              "zainabbawa": {"tguser": "@Saaweoh"},
+              ".*": {"tguser": "Unknown"}
+            }
+          export_to: env
+    outputs:
+      tguser: ${{ env.tguser }}
+
+  event_notify_all:
+    if: ${{ !contains(fromJson('["issues", "issue_comment", "pull_request", "pull_request_review", "push"]'), github.event_name) }}
+    needs: tguser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: html
+          disable_web_page_preview: true
+          message: |
+            <b>${{ github.event_name }}</b> by ${{ needs.tguser.outputs.tguser }} (${{ github.actor }}) in https://github.com/${{ github.repository }}
+
+  event_issues:
+    if: ${{ github.event_name == 'issues' }}
+    needs: tguser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: html
+          disable_web_page_preview: true
+          message: |
+            <b>${{ github.event_name }}/${{ github.event.action }}</b> by ${{ needs.tguser.outputs.tguser }} (${{ github.actor }}): ${{ github.event.issue.title }} ${{ github.event.issue.html_url }}
+
+  event_issue_comment:
+    if: ${{ github.event_name == 'issue_comment' }}
+    needs: tguser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: html
+          disable_web_page_preview: true
+          message: |
+            <b>${{ github.event_name }}/${{ github.event.action }}</b> by ${{ needs.tguser.outputs.tguser }} (${{ github.actor }}) in ${{ github.event.issue.title }} ${{ github.event.issue.html_url }}:
+
+            ${{ github.event.comment.body }} ${{ github.event.comment.html_url }}
+
+  event_pull_request:
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: tguser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: html
+          disable_web_page_preview: true
+          message: |
+            <b>${{ github.event_name }}/${{ github.event.action }}</b> by ${{ needs.tguser.outputs.tguser }} (${{ github.actor }}): ${{ github.event.pull_request.title }} ${{ github.event.pull_request.html_url }}
+
+  event_pull_request_review:
+    if: ${{ github.event_name == 'pull_request_review' }}
+    needs: tguser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: html
+          disable_web_page_preview: true
+          message: |
+            <b>${{ github.event_name }}/${{ github.event.action }} (${{ github.event.review.state }})</b> by ${{ needs.tguser.outputs.tguser }} (${{ github.actor }}) in ${{ github.event.pull_request.title }} ${{ github.event.pull_request.html_url }}:
+
+            ${{ github.event.review.body }} ${{ github.event.review.html_url }}
+
+  event_push:
+    if: ${{ github.event_name == 'push' }}
+    needs: tguser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: html
+          disable_web_page_preview: true
+          message: |
+            <b>${{ github.event_name }}</b> by ${{ needs.tguser.outputs.tguser }} (${{ github.actor }}) in ${{ github.repository }}: ${{ github.event.head_commit.message }} ${{ github.event.compare }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 .pytest_cache
 .cache
 .vscode
+coverage/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.990
     hooks:
       - id: mypy
         # warn-unused-ignores is unsafe with pre-commit, see

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@
   in favour of a unified ``load`` method
 * ``coaster.db`` is deprecated as Flask-SQLAlchemy 3.0 has changed architecture
   to recommend metadata isolation between bind keys even within the same app
+* App config from ``FLASK_*`` env vars is now preferred over config files, and
+  support for the ``FLASK_ENV`` var for custom environments is deprecated
 
 0.6.1 - 2021-01-06
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@
 * Remove unicode_http_header
 * ``loader`` and ``after_loader`` are deprecated in ``coaster.views.ModelView``
   in favour of a unified ``load`` method
+* ``coaster.db`` is deprecated as Flask-SQLAlchemy 3.0 has changed architecture
+  to recommend metadata isolation between bind keys even within the same app
 
 0.6.1 - 2021-01-06
 ------------------

--- a/coaster/app.py
+++ b/coaster/app.py
@@ -109,7 +109,9 @@ class RotatingKeySecureCookieSessionInterface(SecureCookieSessionInterface):
         )
 
 
-def init_app(app: Flask, config: t.List[str] = None, init_logging: bool = True) -> None:
+def init_app(
+    app: Flask, config: t.Optional[t.List[str]] = None, init_logging: bool = True
+) -> None:
     """
     Configure an app depending on the environment.
 

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -16,20 +16,31 @@ recognised and made available via :obj:`current_auth`.
 """
 # pylint: disable=protected-access
 
-from threading import Lock, RLock
+from threading import Lock
 import typing as t
 
 from flask import current_app, g, request
 from werkzeug.local import LocalProxy
+from werkzeug.wrappers import Response as BaseResponse
 
 from .utils import InspectableSet
 
 __all__ = ['add_auth_attribute', 'add_auth_anchor', 'request_has_auth', 'current_auth']
 
+_NOT_FOUND = object()
 # For async/greenlet usage, these are presumed to be monkey-patched by greenlet. The
 # locks are not necessary for thread-safety since there is no cross-thread context here.
-_add_lock = Lock()  # Used by add_auth_attribute
-_get_lock = RLock()  # Used by _get_current_auth, which may get one recursive call
+_add_lock = Lock()  # Used by `add_auth_attribute`
+_get_lock = Lock()  # Used by `_get_current_auth``
+_prop_lock = Lock()  # Used by CurrentAuth's `user` and `actor` properties
+
+_internal_attrs = {
+    'is_placeholder',
+    'actor',
+    'anchors',
+    'is_anonymous',
+    'is_authenticated',
+}
 
 
 def add_auth_attribute(attr: str, value: t.Any, actor: bool = False) -> None:
@@ -51,13 +62,7 @@ def add_auth_attribute(attr: str, value: t.Any, actor: bool = False) -> None:
     2. ``user`` is also made available as ``g._login_user`` for compatibility with
        Flask-Login
     """
-    if attr in (
-        'is_placeholder',
-        'actor',
-        'anchors',
-        'is_anonymous',
-        'is_authenticated',
-    ):
+    if attr in _internal_attrs:
         raise AttributeError(f"Attribute name {attr} is reserved by current_auth")
 
     # Invoking current_auth will also create it on the local stack. We can then proceed
@@ -65,10 +70,9 @@ def add_auth_attribute(attr: str, value: t.Any, actor: bool = False) -> None:
     ca = current_auth._get_current_object()
     if ca.is_placeholder:
         raise RuntimeError("current_auth is a placeholder without a request context")
-    # Since :class:`CurrentAuth` overrides ``__setattr__``, we need to use
-    # :class:`object`'s.
+
     with _add_lock:
-        object.__setattr__(ca, attr, value)
+        ca.__dict__[attr] = value
 
         if attr == 'user':
             # Special-case 'user' for compatibility with Flask-Login
@@ -78,7 +82,7 @@ def add_auth_attribute(attr: str, value: t.Any, actor: bool = False) -> None:
             actor = True
 
         if actor:
-            object.__setattr__(ca, 'actor', value)
+            ca.__dict__['actor'] = value
 
 
 def add_auth_anchor(anchor):
@@ -97,7 +101,11 @@ def request_has_auth():
     the current request. A login manager can use this during request teardown
     to set cookies or perform other housekeeping functions.
     """
-    return bool(request) and hasattr(request, '_current_auth')
+    return (
+        bool(request)
+        and hasattr(request, '_current_auth')
+        and 'actor' in request._current_auth.__dict__
+    )
 
 
 class CurrentAuth:
@@ -131,18 +139,14 @@ class CurrentAuth:
     direct attributes of :obj:`current_auth`.
     """
 
-    user: t.Any
-    actor: t.Any
+    is_placeholder: bool
     permissions: InspectableSet
+    anchors: t.Set
 
-    def __init__(self, user: t.Any, is_placeholder: bool = False) -> None:
+    def __init__(self, is_placeholder: bool = False) -> None:
         object.__setattr__(self, 'is_placeholder', is_placeholder)
-        object.__setattr__(self, 'user', user)
-        object.__setattr__(self, 'actor', user)
         object.__setattr__(self, 'permissions', InspectableSet())
-        object.__setattr__(  # TODO: Placeholder for anchors
-            self, 'anchors', frozenset()
-        )
+        object.__setattr__(self, 'anchors', frozenset())
 
     def __setattr__(self, attr: str, value: t.Any) -> t.NoReturn:
         raise AttributeError('CurrentAuth is read-only')
@@ -166,7 +170,67 @@ class CurrentAuth:
         return self.__dict__.get(attr, default)
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f'CurrentAuth({self.actor!r})'
+        is_placeholder = self.is_placeholder
+        return f'CurrentAuth({is_placeholder=})'
+
+    def _call_login_manager(self):
+        """Call the app's login manager on first access of user or actor (internal)."""
+        # Check for an existing user from Flask-Login
+        if not g:
+            # There's no app or request context
+            return
+        user = g.get('_login_user')
+        if user is not None:
+            self.__dict__['user'] = user
+            if self.__dict__.get('actor') is None:
+                self.__dict__['actor'] = user
+            return
+        # If there's no existing user, look for a login manager
+        if (
+            request
+            and hasattr(current_app, 'login_manager')
+            and hasattr(current_app.login_manager, '_load_user')
+        ):
+            current_app.login_manager._load_user()
+        # In case the login manager did not call :func:`add_auth_attribute`, we'll need
+        # to do it
+        if self.__dict__.get('user') is None:
+            user = g.get('_login_user')
+            if user is not None:
+                self.__dict__['user'] = user
+                # Set actor=user only if the login manager did not add another actor
+                if self.__dict__.get('actor') is None:
+                    self.__dict__['actor'] = user
+
+    @property
+    def actor(self) -> t.Any:
+        """Load and return an actor from auth cookie."""
+        actor = self.__dict__.get('actor', _NOT_FOUND)
+        if actor is not _NOT_FOUND:
+            return actor
+        with _prop_lock:
+            # Check for value being set while waiting for lock
+            actor = self.__dict__.get('actor', _NOT_FOUND)
+            if actor is not _NOT_FOUND:
+                return actor
+            self.__dict__['actor'] = None
+            self._call_login_manager()
+            return self.__dict__['actor']
+
+    @property
+    def user(self) -> t.Any:
+        """Load and return a user from auth cookie."""
+        user = self.__dict__.get('user', _NOT_FOUND)
+        if user is not _NOT_FOUND:
+            return user
+        with _prop_lock:
+            # Check for value being set while waiting for lock
+            user = self.__dict__.get('user', _NOT_FOUND)
+            if user is not _NOT_FOUND:
+                return user
+            self.__dict__['user'] = None
+            self._call_login_manager()
+            return self.__dict__['user']
 
     def __bool__(self) -> bool:
         """Return ``True`` if an actor is present, ``False`` if not."""
@@ -183,52 +247,46 @@ class CurrentAuth:
         return bool(self)
 
 
+def _set_auth_cookie_after_request(response: BaseResponse) -> BaseResponse:
+    # TODO
+    return response
+
+
+def init_app(app):
+    """Optionally initialize current_auth for auth cookie management in an app."""
+    app.config.setdefault('AUTH_COOKIE_NAME', 'auth')
+    for our_config, flask_config in [
+        ('AUTH_COOKIE_DOMAIN', 'SESSION_COOKIE_DOMAIN'),
+        ('AUTH_COOKIE_PATH', 'SESSION_COOKIE_PATH'),
+        ('AUTH_COOKIE_HTTPONLY', 'SESSION_COOKIE_HTTPONLY'),
+        ('AUTH_COOKIE_SECURE', 'SESSION_COOKIE_SECURE'),
+        ('PERMANENT_AUTH_LIFETIME', 'PERMANENT_SESSION_LIFETIME'),
+    ]:
+        app.config.setdefault(our_config, app.config.get(flask_config))
+    app.config.setdefault(
+        'AUTH_SECRET_KEYS',
+        app.config.get('SECRET_KEYS', [app.config.get('SECRET_KEY')]),
+    )
+    app.after_request(_set_auth_cookie_after_request)
+
+
 def _get_current_auth() -> CurrentAuth:
     """Provide current_auth for the request context."""
-    # pylint: disable=too-many-nested-blocks
     # 1. Do we have a request context?
     if request:
         with _get_lock:
-            # 2. Does this app context already have current_auth? If so, return it
+            # 2. Does this request already have current_auth? If so, return it
             ca = getattr(request, '_current_auth', None)
             if ca is None:
-                # 3. If not, does it have a known user (Flask-Login protocol)? If so,
-                # construct current_auth with it
-                request._current_auth = ca = CurrentAuth(  # type: ignore[attr-defined]
-                    g.get('_login_user', None)
-                )
-                # 4. If no existing user, look for a login manager
-                if ca.user is None:
-                    # 4.1. Check for a login manager and call it. Flask-Login,
-                    # Flask-Lastuser or equivalent must add a login_manager
-                    if (
-                        request
-                        and hasattr(current_app, 'login_manager')
-                        and hasattr(current_app.login_manager, '_load_user')
-                    ):
-                        # This call may invoke `current_auth` and result in one
-                        # recursive another call to `_get_current_auth`. To make this
-                        # work, we use a recursive lock in `_get_lock`, and ensure
-                        # `request._current_auth` already exists as a stub
-                        current_app.login_manager._load_user()
-                    # 4.2. In case the login manager did not call
-                    # :func:`add_auth_attribute`, we'll need to do it
-                    if ca.user is None:
-                        user = g.get('_login_user')
-                        if user:
-                            object.__setattr__(ca, 'user', user)
-                            # Set actor=user only if the login manager did not add
-                            # another
-                            if ca.actor is None:
-                                object.__setattr__(ca, 'actor', user)
-
-        # 5. Return current_auth
+                # 3. If not, create it
+                request._current_auth = ca = CurrentAuth()  # type: ignore[attr-defined]
+        # 4. Return current_auth
         return ca
 
-    # 6. Fallback if there is no request context. Return a blank current_auth
+    # 5. Fallback if there is no request context. Return a blank current_auth
     # so that ``current_auth.is_authenticated`` remains valid for checking status
     # Make this work even when there's no request
-    return CurrentAuth(None, is_placeholder=True)
+    return CurrentAuth(is_placeholder=True)
 
 
 #: A proxy object that hosts state for user authentication, attempting to load

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -168,8 +168,7 @@ class CurrentAuth:
         return getattr(self, attr, default)
 
     def __repr__(self) -> str:  # pragma: no cover
-        is_placeholder = self.is_placeholder
-        return f'CurrentAuth({is_placeholder=})'
+        return f'CurrentAuth(is_placeholder={self.is_placeholder})'
 
     def __getattr__(self, attr: str) -> t.Any:
         """Init CurrentAuth on first attribute access."""

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -28,7 +28,6 @@ from .utils import InspectableSet
 
 __all__ = ['add_auth_attribute', 'add_auth_anchor', 'request_has_auth', 'current_auth']
 
-_NOT_FOUND = object()
 # For async/greenlet usage, these are presumed to be monkey-patched by greenlet. The
 # locks are not necessary for thread-safety since there is no cross-thread context here.
 _add_lock = Lock()  # Used by `add_auth_attribute`

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -188,14 +188,19 @@ class CurrentAuth:
         """Call the app's login manager on first access of user or actor (internal)."""
         # Check for an existing user from Flask-Login
         if not g:
-            # There's no app or request context
+            # There's no app or request context for a login manager to operate on
             return
-        user = g.get('_login_user')
-        if user is not None:
-            self.__dict__['user'] = user
-            if self.__dict__.get('actor') is None:
-                self.__dict__['actor'] = user
-            return
+        if not request:
+            # Look for ``g._login_user``, but only when there's no request. The app
+            # context is sometimes reused between requests in a test environment. We may
+            # have a stale ``g`` that was populated in a previous request and have to
+            # call the login manager all over again to get fresh data
+            user = g.get('_login_user')
+            if user is not None:
+                self.__dict__['user'] = user
+                if self.__dict__.get('actor') is None:
+                    self.__dict__['actor'] = user
+                return
         # If there's no existing user, look for a login manager
         if (
             request

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -85,7 +85,7 @@ def add_auth_attribute(attr: str, value: t.Any, actor: bool = False) -> None:
             ca.__dict__['actor'] = value
 
 
-def add_auth_anchor(anchor):
+def add_auth_anchor(anchor) -> None:
     """Add an anchor to current auth (placeholder pending a spec for anchors)."""
     existing = set(current_auth.anchors)
     existing.add(anchor)
@@ -93,9 +93,9 @@ def add_auth_anchor(anchor):
     object.__setattr__(ca, 'anchors', frozenset(existing))
 
 
-def request_has_auth():
+def request_has_auth() -> bool:
     """
-    Check if request accessed auth.
+    Check if :obj:`current_auth` was accessed for an actor in the current request.
 
     Helper function that returns True if :obj:`current_auth` was invoked during
     the current request. A login manager can use this during request teardown

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -30,9 +30,9 @@ __all__ = ['add_auth_attribute', 'add_auth_anchor', 'request_has_auth', 'current
 
 # For async/greenlet usage, these are presumed to be monkey-patched by greenlet. The
 # locks are not necessary for thread-safety since there is no cross-thread context here.
-_add_lock = Lock()  # Used by `add_auth_attribute`
-_get_lock = Lock()  # Used by `_get_current_auth``
-_prop_lock = Lock()  # Used by CurrentAuth's `user` and `actor` properties
+_add_lock = Lock()  # Used by :func:`add_auth_attribute`
+_get_lock = Lock()  # Used by :func:`_get_current_auth``
+_prop_lock = Lock()  # Used by :meth:`CurrentAuth.__getattr__`
 
 _internal_attrs = {
     'is_placeholder',

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -163,6 +163,8 @@ class CurrentAuth:
 
     def get(self, attr: str, default: t.Any = None) -> t.Any:
         """Get an attribute."""
+        # This uses :func:`getattr` instead of looking in :attr:`__dict__` because it
+        # needs to trigger the first-use activity that happens in :meth:`__getattr__`
         return getattr(self, attr, default)
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/coaster/auth.py
+++ b/coaster/auth.py
@@ -2,17 +2,18 @@
 Authentication management
 =========================
 
-Coaster provides a :obj:`current_auth` for handling authentication. Login
-managers must comply with its API for Coaster's view handlers to work.
+Coaster provides a :obj:`current_auth` for handling authentication. Login managers must
+comply with its API for Coaster's view handlers to work.
 
-If a login manager installs itself as ``current_app.login_manager`` and
-provides a ``_load_user()`` method, it will be called when :obj:`current_auth`
-is invoked for the first time in a request. Login managers can call
-:func:`add_auth_attribute` to load the actor (typically the authenticated user)
-and any other relevant authentication attributes.
-
-For compatibility with Flask-Login, a user object loaded at ``g._login_user`` will be
-recognised and made available via :obj:`current_auth`.
+If a login manager installs itself as ``current_app.login_manager`` and provides a
+``_load_user()`` method, it will be called when :obj:`current_auth` is invoked for the
+first time in a request. Login managers can call :func:`add_auth_attribute` to load the
+actor (typically the authenticated user) and any other relevant authentication
+attributes. For compatibility with Flask-Login, if the login manager fails to call
+:func:`add_auth_attribute`, :obj:`current_auth` will attempt to load a user from
+``g._login_user``. However, this value will not be trusted unless a login manager is
+called, as the app context may be re-used between requests if it was created prior to
+request processing.
 """
 # pylint: disable=protected-access
 

--- a/coaster/db.py
+++ b/coaster/db.py
@@ -15,9 +15,7 @@ db = SQLAlchemy()
 # be issued once per connection.
 @event.listens_for(Engine, 'connect')
 def _set_sqlite_pragma(dbapi_connection, connection_record):
-    if isinstance(  # pragma: no cover
-        dbapi_connection, (SQLite3Connection, SQLite3Connection)
-    ):
+    if isinstance(dbapi_connection, SQLite3Connection):  # pragma: no cover
         cursor = dbapi_connection.cursor()
         cursor.execute('PRAGMA foreign_keys=ON;')
         cursor.close()

--- a/coaster/db.py
+++ b/coaster/db.py
@@ -1,3 +1,12 @@
+"""
+Flask-SQLAlchemy instance
+-------------------------
+
+.. deprecated:: 0.7.0
+   Coaster provides a global instance of Flask-SQLAlchemy for convenience, but this is
+   deprecated as of Flask-SQLAlchemy 3.0 as it now applies metadata isolation between
+   binds even within the same app.
+"""
 from sqlite3 import Connection as SQLite3Connection
 
 from flask_sqlalchemy import SQLAlchemy

--- a/coaster/sqlalchemy/annotations.py
+++ b/coaster/sqlalchemy/annotations.py
@@ -12,10 +12,11 @@ This module's exports may be imported via :mod:`coaster.sqlalchemy`.
 
 Sample usage::
 
-    from coaster.db import db
+    from flask_sqlalchemy import SQLAlchemy
     from coaster.sqlalchemy import annotation_wrapper, immutable
 
     natural_key = annotation_wrapper('natural_key', "Natural key for this model")
+    db = SQLAlchemy()
 
     class MyModel(db.Model):
         __tablename__ = 'my_model'

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -720,9 +720,11 @@ def with_roles(
     read: t.Optional[t.Set[str]] = None,
     write: t.Optional[t.Set[str]] = None,
     grants: t.Optional[t.Set[str]] = None,
-    grants_via: t.Dict[
-        t.Union[None, str, QueryableAttribute],
-        t.Union[t.Set[str], t.Dict[str, str], t.Dict[str, t.Set[str]]],
+    grants_via: t.Optional[
+        t.Dict[
+            t.Union[None, str, QueryableAttribute],
+            t.Union[t.Set[str], t.Dict[str, str], t.Dict[str, t.Set[str]]],
+        ]
     ] = None,
     datasets: t.Optional[t.Set[str]] = None,
 ):

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -176,6 +176,7 @@ class RoleAttrs(te.TypedDict, total=False):
     rw: t.Set[str]
     read: t.Set[str]
     write: t.Set[str]
+    call: t.Set[str]
     grants: t.Set[str]
     granted_by: t.List[str]
     granted_via: t.Dict[str, t.Union[None, str, QueryableAttribute]]
@@ -721,7 +722,7 @@ def with_roles(
     grants: t.Optional[t.Set[str]] = None,
     grants_via: t.Dict[
         t.Union[None, str, QueryableAttribute],
-        t.Union[t.Set[str], t.Dict[str, t.Union[str, t.Set[str]]]],
+        t.Union[t.Set[str], t.Dict[str, str], t.Dict[str, t.Set[str]]],
     ] = None,
     datasets: t.Optional[t.Set[str]] = None,
 ):

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -173,12 +173,12 @@ __cache__: t.Dict[t.Any, t.Dict[str, set]] = {}
 class RoleAttrs(te.TypedDict):
     """Type definition for values in :attr:`RoleMixin.__roles__`."""
 
-    rw: t.Set[str]
-    read: t.Set[str]
-    write: t.Set[str]
-    grants: t.Set[str]
-    granted_by: t.List[str]
-    granted_via: t.Dict[str, str]
+    rw: te.NotRequired[t.Set[str]]
+    read: te.NotRequired[t.Set[str]]
+    write: te.NotRequired[t.Set[str]]
+    grants: te.NotRequired[t.Set[str]]
+    granted_by: te.NotRequired[t.List[str]]
+    granted_via: te.NotRequired[t.Dict[str, t.Union[str, QueryableAttribute]]]
 
 
 def _attrs_equal(lhs, rhs):
@@ -714,13 +714,16 @@ class RoleAccessProxy(abc.Mapping):
 def with_roles(
     obj=None,
     *,
-    rw=None,
-    call=None,
-    read=None,
-    write=None,
-    grants=None,
-    grants_via=None,
-    datasets=None,
+    rw: t.Optional[t.Set[str]] = None,
+    call: t.Optional[t.Set[str]] = None,
+    read: t.Optional[t.Set[str]] = None,
+    write: t.Optional[t.Set[str]] = None,
+    grants: t.Optional[t.Set[str]] = None,
+    grants_via: t.Dict[
+        t.Union[None, str, QueryableAttribute],
+        t.Union[t.Set[str], t.Dict[str, t.Union[str, t.Set[str]]]],
+    ] = None,
+    datasets: t.Optional[t.Set[str]] = None,
 ):
     """
     Define roles on an attribute and return the attribute.
@@ -826,7 +829,7 @@ def with_roles(
     if not grants_via:
         grants_via = {}
     if not datasets:
-        datasets = {}
+        datasets = set()
     # `rw` is shorthand for read+write
     read.update(rw)
     write.update(rw)

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -125,11 +125,14 @@ from abc import ABCMeta
 from collections import abc
 from copy import deepcopy
 from itertools import chain
+from typing import overload
 import operator
 import typing as t
 
 from sqlalchemy.ext.orderinglist import OrderingList
 from sqlalchemy.orm import ColumnProperty, Query, RelationshipProperty, SynonymProperty
+
+import typing_extensions as te
 
 try:  # SQLAlchemy >= 1.4
     from sqlalchemy.orm import MapperProperty  # type: ignore[attr-defined]
@@ -165,6 +168,17 @@ __all__ = [
 
 # Global dictionary for temporary storage of roles until the mapper_configured events
 __cache__: t.Dict[t.Any, t.Dict[str, set]] = {}
+
+
+class RoleAttrs(te.TypedDict):
+    """Type definition for values in :attr:`RoleMixin.__roles__`."""
+
+    rw: t.Set[str]
+    read: t.Set[str]
+    write: t.Set[str]
+    grants: t.Set[str]
+    granted_by: t.List[str]
+    granted_via: t.Dict[str, str]
 
 
 def _attrs_equal(lhs, rhs):
@@ -699,6 +713,7 @@ class RoleAccessProxy(abc.Mapping):
 
 def with_roles(
     obj=None,
+    *,
     rw=None,
     call=None,
     read=None,
@@ -801,6 +816,7 @@ def with_roles(
             }}
         )
     """
+    # pylint: disable=protected-access
     # Convert lists and None values to sets
     rw = set(rw) if rw else set()
     call = set(call) if call else set()
@@ -848,9 +864,6 @@ def with_roles(
                 pass
         return attr
 
-    if is_collection(obj):
-        # Protect against accidental specification of roles instead of an object
-        raise TypeError('Roles must be specified as named parameters')
     if obj is not None:
         return inner(obj)
     return inner
@@ -882,9 +895,7 @@ class RoleMixin:
     """
 
     # This empty dictionary is necessary for the configure step below to work
-    __roles__: t.Dict[
-        str, t.Dict[str, t.Union[t.Set[str], t.List[str], t.Dict[str, t.Optional[str]]]]
-    ] = {}
+    __roles__: t.Dict[str, RoleAttrs] = {}
     # Datasets for limited access to attributes
     __datasets__: t.Dict[str, t.Set[str]] = {}
     # Datasets to use when rendering to JSON
@@ -892,7 +903,7 @@ class RoleMixin:
     # Relationship role offer map (used by LazyRoleSet)
     __relationship_role_offer_map__: t.Dict[str, t.Set[str]] = {}
     # Relationship reversed role offer map (used by actors_with)
-    __relationship_reversed_role_offer_map__: t.Dict[str, t.Set[str]] = {}
+    __relationship_reversed_role_offer_map__: t.Dict[str, t.Dict[str, t.Set[str]]] = {}
 
     def roles_for(
         self, actor: t.Optional[t.Any] = None, anchors: t.Iterable = ()
@@ -972,7 +983,21 @@ class RoleMixin:
             relationship = getattr(self, relattr)
         return relationship
 
-    def actors_with(self, roles, with_role=False):
+    @overload
+    def actors_with(
+        self, roles: t.AbstractSet[str], with_role: te.Literal[False] = False
+    ) -> t.Any:
+        ...
+
+    @overload
+    def actors_with(
+        self, roles: t.AbstractSet[str], with_role: te.Literal[True] = True
+    ) -> t.Tuple[t.Any, str]:
+        ...
+
+    def actors_with(
+        self, roles: t.AbstractSet[str], with_role: bool = False
+    ) -> t.Union[t.Any, t.Tuple[str, t.Any]]:
         """
         Return actors who have the specified roles on this object, as an iterator.
 
@@ -1013,7 +1038,9 @@ class RoleMixin:
 
         for role in roles:
             # Scan granted_by declarations
-            for relattr in self.__roles__.get(role, {}).get('granted_by', []):
+            for relattr in self.__roles__.get(  # type: ignore[call-overload]
+                role, {}
+            ).get('granted_by', []):
                 relationship = getattr(self, relattr)
                 if isinstance(relationship, (AppenderQuery, Query, abc.Iterable)):
                     for actor in relationship:
@@ -1023,7 +1050,9 @@ class RoleMixin:
                     yield (relationship, role) if with_role else relationship
             # Scan granted_via declarations
             for relattr, actor_attr in (
-                self.__roles__.get(role, {}).get('granted_via', {}).items()
+                self.__roles__.get(role, {})  # type: ignore[call-overload]
+                .get('granted_via', {})
+                .items()
             ):
                 reverse_offer_map = self.__relationship_reversed_role_offer_map__.get(
                     relattr

--- a/coaster/sqlalchemy/roles.py
+++ b/coaster/sqlalchemy/roles.py
@@ -170,15 +170,15 @@ __all__ = [
 __cache__: t.Dict[t.Any, t.Dict[str, set]] = {}
 
 
-class RoleAttrs(te.TypedDict):
+class RoleAttrs(te.TypedDict, total=False):
     """Type definition for values in :attr:`RoleMixin.__roles__`."""
 
-    rw: te.NotRequired[t.Set[str]]
-    read: te.NotRequired[t.Set[str]]
-    write: te.NotRequired[t.Set[str]]
-    grants: te.NotRequired[t.Set[str]]
-    granted_by: te.NotRequired[t.List[str]]
-    granted_via: te.NotRequired[t.Dict[str, t.Union[str, QueryableAttribute]]]
+    rw: t.Set[str]
+    read: t.Set[str]
+    write: t.Set[str]
+    grants: t.Set[str]
+    granted_by: t.List[str]
+    granted_via: t.Dict[str, t.Union[None, str, QueryableAttribute]]
 
 
 def _attrs_equal(lhs, rhs):

--- a/coaster/sqlalchemy/statemanager.py
+++ b/coaster/sqlalchemy/statemanager.py
@@ -296,7 +296,7 @@ class AbortTransition(Exception):  # noqa: N818
     :param result: Value to return to the transition's caller
     """
 
-    def __init__(self, result=None):  # pylint:disable=useless-super-delegation
+    def __init__(self, result=None):  # pylint: disable=useless-super-delegation
         super().__init__(result)
 
 

--- a/coaster/sqlalchemy/statemanager.py
+++ b/coaster/sqlalchemy/statemanager.py
@@ -357,6 +357,7 @@ class ManagedState:
 
     def _eval(self, obj, cls=None):
         # TODO: Respect cache as specified in `cache_for`
+        # pylint: disable=protected-access
         if obj is not None:  # We're being called with an instance
             if is_collection(self.value):
                 valuematch = self.statemanager._value(obj, cls) in self.value

--- a/coaster/sqlalchemy/statemanager.py
+++ b/coaster/sqlalchemy/statemanager.py
@@ -317,7 +317,7 @@ class ManagedState:
         statemanager: StateManager,
         value: t.Any,
         label: t.Optional[str] = None,
-        validator: t.Callable[[t.Any], bool] = None,
+        validator: t.Optional[t.Callable[[t.Any], bool]] = None,
         class_validator: t.Optional[t.Callable[[t.Any], None]] = None,
         cache_for: t.Union[None, int, t.Callable] = None,
     ):

--- a/coaster/utils/misc.py
+++ b/coaster/utils/misc.py
@@ -69,30 +69,13 @@ _ipv4_re = re.compile(
 # --- Utilities ------------------------------------------------------------------------
 
 
-@overload
-def is_collection(item: t.Union[str, bytes, t.Dict]) -> te.Literal[False]:
-    ...
-
-
-@overload
-def is_collection(
-    item: t.Union[t.List, t.Tuple, t.Set, t.KeysView]
-) -> te.Literal[True]:
-    ...
-
-
-@overload
-def is_collection(item: t.Any) -> bool:
-    ...
-
-
 def is_collection(item: t.Any) -> bool:
     """
-    Return True if the item is a collection class.
+    Return True if the item is a collection class but not a string or dict.
 
     List, tuple, set, frozenset or any other class that resembles one of these (using
-    abstract base classes). ``collections.abc.Collection`` is not suitable as it also
-    matches strings and dicts.
+    abstract base classes). Using ``collections.abc.Collection`` directly is not
+    suitable as it also matches strings and dicts.
 
     >>> is_collection(0)
     False
@@ -118,9 +101,7 @@ def is_collection(item: t.Any) -> bool:
     >>> is_collection(InspectableSet({1, 2}))
     True
     """
-    return not isinstance(item, (str, bytes)) and isinstance(
-        item, (abc.Set, abc.Sequence)
-    )
+    return not isinstance(item, (str, bytes, dict)) and isinstance(item, abc.Collection)
 
 
 def uuid_b64() -> str:

--- a/coaster/views/classview.py
+++ b/coaster/views/classview.py
@@ -661,7 +661,7 @@ class ModelView(ClassView):
 
     def dispatch_request(
         self, view: t.Callable[..., ResponseReturnValue], view_args: t.Dict[str, t.Any]
-    ) -> ResponseReturnValue:
+    ) -> BaseResponse:
         """
         Dispatch a view.
 

--- a/coaster/views/classview.py
+++ b/coaster/views/classview.py
@@ -350,7 +350,10 @@ class ViewHandlerWrapper:
     """Wrapper for a view at runtime."""
 
     def __init__(
-        self, viewh: ViewHandler, obj: ClassView, cls: t.Type[ClassView] = None
+        self,
+        viewh: ViewHandler,
+        obj: ClassView,
+        cls: t.Optional[t.Type[ClassView]] = None,
     ):
         # obj is the ClassView instance
         self._viewh = viewh

--- a/coaster/views/decorators.py
+++ b/coaster/views/decorators.py
@@ -746,7 +746,7 @@ def requires_permission(
         def is_available_here() -> bool:
             if not current_auth.permissions:
                 return False
-            if is_collection(permission):
+            if isinstance(permission, (set, frozenset)):
                 return bool(current_auth.permissions & permission)  # type: ignore
             return permission in current_auth.permissions  # type: ignore[unreachable]
 

--- a/coaster/views/decorators.py
+++ b/coaster/views/decorators.py
@@ -727,9 +727,7 @@ def cors(
     return decorator
 
 
-def requires_permission(
-    permission: t.Union[str, t.Collection[str]]
-) -> tc.ReturnDecorator:
+def requires_permission(permission: t.Union[str, t.Set[str]]) -> tc.ReturnDecorator:
     """
     Decorate to require a permission to be present in ``current_auth.permissions``.
 

--- a/coaster/views/decorators.py
+++ b/coaster/views/decorators.py
@@ -747,8 +747,8 @@ def requires_permission(
             if not current_auth.permissions:
                 return False
             if is_collection(permission):
-                return bool(current_auth.permissions & permission)
-            return permission in current_auth.permissions
+                return bool(current_auth.permissions & permission)  # type: ignore
+            return permission in current_auth.permissions  # type: ignore[unreachable]
 
         def is_available(context=None) -> bool:
             result = is_available_here()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = [
     'Flask-Assets',
     'Flask-Migrate',
     'Flask-Script',
-    'Flask-SQLAlchemy',
+    'Flask-SQLAlchemy>=3.0',
     'Flask>=2.0',
     'furl',
     'html2text>2019.8.11',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,6 +6,7 @@ pylint-pytest
 pytest>6
 pytest-cov
 pytest-env
+pytest-ignore-flaky
 pytest-remotedata
 pytest-rerunfailures
 toml

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,4 +9,4 @@ MAIL_PORT = 587
 MAIL_USERNAME = 'username'
 MAIL_PASSWORD = 'PASSWORD'  # nosec
 SECRET_KEY = 'd vldvnvnvjn'  # nosec
-SQLALCHEMY_DATABASE_URI = 'postgresql:///coaster_test'
+SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/coaster_test'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,13 +1,14 @@
 """Test current_auth."""
 
+# These unused imports are present to mitigate a bug in sqlalchemy2-stubs for mypy
+from types import SimpleNamespace
 import typing as t  # noqa: F401  # pylint: disable=unused-import
-import unittest
 import uuid as uuid_  # noqa: F401  # pylint: disable=unused-import
 
 from flask_sqlalchemy import SQLAlchemy
 import sqlalchemy as sa  # noqa: F401  # pylint: disable=unused-import
 
-from flask import Flask, g, has_request_context
+from flask import Flask, g, has_request_context, render_template_string
 
 import pytest
 
@@ -21,20 +22,22 @@ from coaster.sqlalchemy import BaseMixin
 
 # --- App context ----------------------------------------------------------------------
 
-db = SQLAlchemy()
 
+class LoginManager:  # pylint: disable=too-few-public-methods
+    """Test login manager implementing _load_user method."""
 
-class LoginManager:
-    def __init__(self, app):
+    def __init__(self, app):  # pylint: disable=redefined-outer-name
         app.login_manager = self
         self.user = None
 
     def set_user_for_testing(self, user, load=False):
+        """Test auth by setting a user."""
         self.user = user
         if load:
             self._load_user()
 
     def _load_user(self):
+        """Load user into current_auth."""
         if has_request_context():
             add_auth_attribute('user', self.user)
             if self.user:
@@ -44,186 +47,258 @@ class LoginManager:
 # --- Models ---------------------------------------------------------------------------
 
 
-class User(BaseMixin, db.Model):  # type: ignore[name-defined]
-    __tablename__ = 'authenticated_user'
-    username = db.Column(db.Unicode(80))
-    fullname = db.Column(db.Unicode(80))
+@pytest.fixture(scope='module')
+def models(db) -> SimpleNamespace:
+    """Model fixtures."""
+    # pylint: disable=possibly-unused-variable
+
+    class User(BaseMixin, db.Model):  # type: ignore[name-defined]
+        """Test user model."""
+
+        __tablename__ = 'authenticated_user'
+        username = db.Column(db.Unicode(80))
+        fullname = db.Column(db.Unicode(80))
+
+    class AnonymousUser(BaseMixin, db.Model):  # type: ignore[name-defined]
+        """Test anonymous user model."""
+
+        __tablename__ = 'anonymous_user'
+        is_anonymous = True
+        username = 'anon'
+        fullname = 'Anonymous'
+
+    class Client(BaseMixin, db.Model):  # type: ignore[name-defined]
+        """Test client model."""
+
+        __tablename__ = 'client'
+
+    return SimpleNamespace(**locals())
 
 
-class AnonymousUser(BaseMixin, db.Model):  # type: ignore[name-defined]
-    __tablename__ = 'anonymous_user'
-    is_anonymous = True
-    username = 'anon'
-    fullname = 'Anonymous'
+# --- Fixtures -------------------------------------------------------------------------
 
 
-class Client(BaseMixin, db.Model):  # type: ignore[name-defined]
-    __tablename__ = 'client'
+@pytest.fixture(scope='module')
+def app() -> Flask:
+    """App fixture."""
+    _app = Flask(__name__)
+    _app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    _app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    return _app
+
+
+@pytest.fixture(scope='module')
+def db(app) -> SQLAlchemy:
+    """Database fixture."""
+    _db = SQLAlchemy(app)
+    return _db
+
+
+@pytest.fixture()
+def login_manager(app):
+    """Login manager fixture."""
+    return LoginManager(app)
+
+
+@pytest.fixture()
+def ctx(app, db):
+    """App request context with database models."""
+    db.init_app(app)
+    _ctx = app.test_request_context()
+    _ctx.push()
+    db.create_all()
+    yield _ctx
+    db.session.rollback()
+    db.drop_all()
+    _ctx.pop()
 
 
 # --- Tests ----------------------------------------------------------------------------
 
 
-class TestCurrentUserNoRequest(unittest.TestCase):
-    def test_current_auth_no_request(self):
-        assert current_auth.is_anonymous
-        assert not current_auth.is_authenticated
-        assert current_auth.user is None
+def test_current_auth_no_request():
+    """Test case for no app or request context."""
+    assert current_auth.is_anonymous
+    assert not current_auth.is_authenticated
+    assert current_auth.user is None
 
 
-class TestCurrentUserNoLoginManager(unittest.TestCase):
-    app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-
-    def setUp(self):
-        db.init_app(self.app)
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
-        db.create_all()
-        self.session = db.session
-
-    def tearDown(self):
-        self.session.rollback()
-        db.drop_all()
-        self.ctx.pop()
-
-    def test_current_auth_no_login_manager(self):
-        assert current_auth.is_anonymous
-        assert not current_auth.is_authenticated
-        assert current_auth.user is None
+@pytest.mark.usefixtures('ctx')
+def test_current_auth_no_login_manager():
+    """Test current_auth without a login manager."""
+    assert current_auth.is_anonymous
+    assert not current_auth.is_authenticated
+    assert current_auth.user is None
 
 
-class TestCurrentUserWithLoginManager(unittest.TestCase):
-    app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    login_manager = LoginManager(app)
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_current_auth_without_user():
+    assert current_auth.is_anonymous
+    assert not current_auth.is_authenticated
+    assert not current_auth
+    assert current_auth.user is None
+    assert current_auth.actor is None
 
-    def setUp(self):
-        db.init_app(self.app)
-        self.ctx = self.app.test_request_context()
-        self.ctx.push()
-        db.create_all()
-        self.session = db.session
 
-    def tearDown(self):
-        self.login_manager.set_user_for_testing(None, load=True)
-        self.session.rollback()
-        db.drop_all()
-        self.ctx.pop()
+@pytest.mark.usefixtures('ctx')
+def test_current_auth_with_user_unloaded(models, login_manager):
+    user = models.User(username='foo', fullname='Mr Foo')
+    login_manager.set_user_for_testing(user)
 
-    def test_current_auth_without_user(self):
-        assert current_auth.is_anonymous
-        assert not current_auth.is_authenticated
-        assert not current_auth
-        assert current_auth.user is None
-        assert current_auth.actor is None
+    assert not current_auth.is_anonymous
+    assert current_auth.is_authenticated
+    assert current_auth
+    assert current_auth.user is not None
+    assert current_auth.user == user
+    assert current_auth.actor == user
 
-    def test_current_auth_with_user_unloaded(self):
-        user = User(username='foo', fullname='Mr Foo')
-        self.login_manager.set_user_for_testing(user)
+    # Additional auth details (username only in this test) exposed by the login manager
+    assert current_auth.username == 'foo'
+    with pytest.raises(AttributeError):
+        assert current_auth.fullname == 'Mr Foo'
 
-        assert not current_auth.is_anonymous
-        assert current_auth.is_authenticated
-        assert current_auth
-        assert current_auth.user is not None
-        assert current_auth.user == user
-        assert current_auth.actor == user
+    # current_user is immutable
+    with pytest.raises(AttributeError):
+        current_auth.username = 'bar'
 
-        # Additional auth details (username only in this test) exposed by the login manager
-        assert current_auth.username == 'foo'
+    # For full attribute access, use the user object
+    assert current_auth.user.username == 'foo'
+    assert current_auth.user.fullname == 'Mr Foo'
+
+
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_current_auth_with_flask_login_user(models):
+    user = models.User(username='foo', fullname='Mr Foo')
+    g._login_user = user  # pylint: disable=protected-access
+
+    assert not current_auth.is_anonymous
+    assert current_auth.is_authenticated
+    assert current_auth
+    assert current_auth.user is not None
+    assert current_auth.user == user
+    assert current_auth.actor == user
+
+
+@pytest.mark.usefixtures('ctx')
+def test_current_auth_with_user_loaded(models, login_manager):
+    assert current_auth.is_anonymous
+    assert not current_auth.is_authenticated
+    assert not current_auth
+    assert current_auth.user is None
+    assert current_auth.actor is None
+
+    user = models.User(username='foo', fullname='Mr Foo')
+    login_manager.set_user_for_testing(user, load=True)
+
+    assert not current_auth.is_anonymous
+    assert current_auth.is_authenticated
+    assert current_auth
+    assert current_auth.user is not None
+    assert current_auth.user == user  # type: ignore[unreachable]
+    assert current_auth.actor == user
+
+
+@pytest.mark.usefixtures('ctx')
+def test_anonymous_user(models, login_manager):
+    assert current_auth.is_anonymous
+    assert not current_auth.is_authenticated
+    assert not current_auth
+    assert current_auth.user is None
+
+    user = models.AnonymousUser()
+    login_manager.set_user_for_testing(user, load=True)
+
+    # is_authenticated == True, since there is an actor
+    assert current_auth.is_authenticated  # type: ignore[unreachable]
+    assert current_auth
+    assert current_auth.actor is not None
+    assert current_auth.user == user
+    assert current_auth.actor == user
+
+
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_invalid_auth_attribute():
+    for attr in (
+        'actor',
+        'anchors',
+        'is_anonymous',
+        'is_authenticated',
+    ):
         with pytest.raises(AttributeError):
-            assert current_auth.fullname == 'Mr Foo'
+            add_auth_attribute(attr, None)
 
-        # current_user is immutable
-        with pytest.raises(AttributeError):
-            current_auth.username = 'bar'
 
-        # For full attribute access, use the user object
-        assert current_auth.user.username == 'foo'
-        assert current_auth.user.fullname == 'Mr Foo'
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_other_actor_authenticated(models):
+    assert current_auth.is_anonymous
+    assert not current_auth.is_authenticated
+    assert not current_auth
+    assert current_auth.user is None
 
-    def test_current_auth_with_flask_login_user(self):
-        user = User(username='foo', fullname='Mr Foo')
-        g._login_user = user  # pylint: disable=protected-access
+    client = models.Client()
+    add_auth_attribute('client', client, actor=True)
 
-        assert not current_auth.is_anonymous
-        assert current_auth.is_authenticated
-        assert current_auth
-        assert current_auth.user is not None
-        assert current_auth.user == user
-        assert current_auth.actor == user
+    assert not current_auth.is_anonymous
+    assert current_auth.is_authenticated
+    assert current_auth
+    assert current_auth.user is None  # It's not the user
+    assert current_auth.client == client  # There's now a client attribute
+    assert current_auth.actor == client  # The client is also the actor
 
-    def test_current_auth_with_user_loaded(self):
-        assert current_auth.is_anonymous
-        assert not current_auth.is_authenticated
-        assert not current_auth
-        assert current_auth.user is None
-        assert current_auth.actor is None
 
-        user = User(username='foo', fullname='Mr Foo')
-        self.login_manager.set_user_for_testing(user, load=True)
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_auth_anchor():
+    """A request starts with zero anchors, but they can be added"""
+    assert not current_auth.anchors
+    add_auth_anchor('test-anchor')
+    assert current_auth.anchors
+    assert current_auth.anchors == {'test-anchor'}
 
-        assert not current_auth.is_anonymous
-        assert current_auth.is_authenticated
-        assert current_auth
-        assert current_auth.user is not None
-        assert current_auth.user == user  # type: ignore[unreachable]
-        assert current_auth.actor == user
 
-    def test_anonymous_user(self):
-        assert current_auth.is_anonymous
-        assert not current_auth.is_authenticated
-        assert not current_auth
-        assert current_auth.user is None
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_has_current_auth():
+    """request_has_auth indicates if current_auth was invoked during a request"""
+    assert not request_has_auth()
+    # Invoke current_auth
+    current_auth.is_anonymous  # pylint: disable=W0104
+    assert request_has_auth()
 
-        user = AnonymousUser()
-        self.login_manager.set_user_for_testing(user, load=True)
 
-        # is_authenticated == True, since there is an actor
-        assert current_auth.is_authenticated  # type: ignore[unreachable]
-        assert current_auth
-        assert current_auth.actor is not None
-        assert current_auth.user == user
-        assert current_auth.actor == user
+@pytest.mark.usefixtures('ctx', 'login_manager')
+def test_jinja2_no_auth(app):
+    """Test that current_auth is available in Jinja2."""
+    app.jinja_env.globals['current_auth'] = current_auth
+    assert not request_has_auth()
+    assert render_template_string("{% if config %}Yes{% else %}No{% endif %}") == 'Yes'
+    assert not request_has_auth()
+    assert (
+        render_template_string('{% if current_auth %}Yes{% else %}No{% endif %}')
+        == 'No'
+    )
+    assert (
+        render_template_string(
+            '{% if current_auth.is_authenticated %}Yes{% else %}No{% endif %}'
+        )
+        == 'No'
+    )
+    assert request_has_auth()
 
-    def test_invalid_auth_attribute(self):
-        for attr in (
-            'actor',
-            'anchors',
-            'is_anonymous',
-            'is_authenticated',
-        ):
-            with pytest.raises(AttributeError):
-                add_auth_attribute(attr, None)
 
-    def test_other_actor_authenticated(self):
-        assert current_auth.is_anonymous
-        assert not current_auth.is_authenticated
-        assert not current_auth
-        assert current_auth.user is None
-
-        client = Client()
-        add_auth_attribute('client', client, actor=True)
-
-        assert not current_auth.is_anonymous
-        assert current_auth.is_authenticated
-        assert current_auth
-        assert current_auth.user is None  # It's not the user
-        assert current_auth.client == client  # There's now a client attribute
-        assert current_auth.actor == client  # The client is also the actor
-
-    def test_auth_anchor(self):
-        """A request starts with zero anchors, but they can be added"""
-        assert not current_auth.anchors
-        add_auth_anchor('test-anchor')
-        assert current_auth.anchors
-        assert current_auth.anchors == {'test-anchor'}
-
-    def test_has_current_auth(self):
-        """request_has_auth indicates if current_auth was invoked during a request"""
-        assert not request_has_auth()
-        # Invoke current_auth
-        current_auth.is_anonymous  # pylint: disable=W0104
-        assert request_has_auth()
+@pytest.mark.usefixtures('ctx')
+def test_jinja2_auth(app, models, login_manager):
+    """Test that current_auth is available in Jinja2."""
+    app.jinja_env.globals['current_auth'] = current_auth
+    user = models.AnonymousUser()
+    login_manager.set_user_for_testing(user, load=True)
+    assert render_template_string("{% if config %}Yes{% else %}No{% endif %}") == 'Yes'
+    assert (
+        render_template_string('{% if current_auth %}Yes{% else %}No{% endif %}')
+        == 'Yes'
+    )
+    assert (
+        render_template_string(
+            '{% if current_auth.is_authenticated %}Yes{% else %}No{% endif %}'
+        )
+        == 'Yes'
+    )
+    assert request_has_auth()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,5 @@
+"""Test current_auth."""
+
 import typing as t  # noqa: F401  # pylint: disable=unused-import
 import unittest
 import uuid as uuid_  # noqa: F401  # pylint: disable=unused-import

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -288,13 +288,16 @@ def test_jinja2_no_auth(app):
 def test_jinja2_auth(app, models, login_manager):
     """Test that current_auth is available in Jinja2."""
     app.jinja_env.globals['current_auth'] = current_auth
-    user = models.AnonymousUser()
-    login_manager.set_user_for_testing(user, load=True)
+    user = models.User(username='user', fullname="User")
+    login_manager.set_user_for_testing(user)
+    assert not request_has_auth()
     assert render_template_string("{% if config %}Yes{% else %}No{% endif %}") == 'Yes'
+    assert not request_has_auth()
     assert (
         render_template_string('{% if current_auth %}Yes{% else %}No{% endif %}')
         == 'Yes'
     )
+    assert request_has_auth()
     assert (
         render_template_string(
             '{% if current_auth.is_authenticated %}Yes{% else %}No{% endif %}'
@@ -302,3 +305,4 @@ def test_jinja2_auth(app, models, login_manager):
         == 'Yes'
     )
     assert request_has_auth()
+    assert render_template_string('{{ current_auth.user.username }}') == 'user'

--- a/tests/test_sqlalchemy_annotations.py
+++ b/tests/test_sqlalchemy_annotations.py
@@ -11,7 +11,6 @@ from flask import Flask
 
 import pytest
 
-from coaster.db import db
 from coaster.sqlalchemy import (
     BaseMixin,
     ImmutableColumnError,
@@ -19,6 +18,8 @@ from coaster.sqlalchemy import (
     cached,
     immutable,
 )
+
+from .test_sqlalchemy_models import db
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
@@ -29,11 +30,11 @@ db.init_app(app)
 # --- Models ---------------------------------------------------------------------------
 
 
-class ReferralTarget(BaseMixin, db.Model):
+class ReferralTarget(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'referral_target'
 
 
-class IdOnly(BaseMixin, db.Model):
+class IdOnly(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'id_only'
     __uuid_primary_key__ = False
 
@@ -48,7 +49,7 @@ class IdOnly(BaseMixin, db.Model):
     referral_target = db.relationship(ReferralTarget)
 
 
-class IdUuid(UuidMixin, BaseMixin, db.Model):
+class IdUuid(UuidMixin, BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'id_uuid'
     __uuid_primary_key__ = False
 
@@ -63,7 +64,7 @@ class IdUuid(UuidMixin, BaseMixin, db.Model):
     referral_target = immutable(db.relationship(ReferralTarget))
 
 
-class UuidOnly(UuidMixin, BaseMixin, db.Model):
+class UuidOnly(UuidMixin, BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_only'
     __uuid_primary_key__ = True
 
@@ -78,7 +79,7 @@ class UuidOnly(UuidMixin, BaseMixin, db.Model):
     referral_target = immutable(db.relationship(ReferralTarget))
 
 
-class PolymorphicParent(BaseMixin, db.Model):
+class PolymorphicParent(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'polymorphic_parent'
     ptype = immutable(db.Column('type', db.Unicode(30), index=True))
     is_immutable = immutable(db.Column(db.Unicode(250), default='my_default'))
@@ -108,7 +109,7 @@ class PolymorphicChild(PolymorphicParent):
 warnings.resetwarnings()
 
 
-class SynonymAnnotation(BaseMixin, db.Model):
+class SynonymAnnotation(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'synonym_annotation'
     col_regular = db.Column(db.Unicode())
     col_immutable = immutable(db.Column(db.Unicode()))

--- a/tests/test_sqlalchemy_coordinates.py
+++ b/tests/test_sqlalchemy_coordinates.py
@@ -6,13 +6,12 @@ import uuid as uuid_  # noqa: F401  # pylint: disable=unused-import
 
 import sqlalchemy as sa  # noqa: F401  # pylint: disable=unused-import
 
-from coaster.db import db
 from coaster.sqlalchemy import BaseMixin, CoordinatesMixin
 
-from .test_sqlalchemy_models import app2
+from .test_sqlalchemy_models import app2, db
 
 
-class CoordinatesData(BaseMixin, CoordinatesMixin, db.Model):
+class CoordinatesData(BaseMixin, CoordinatesMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'coordinates_data'
 
 

--- a/tests/test_sqlalchemy_markdowncolumn.py
+++ b/tests/test_sqlalchemy_markdowncolumn.py
@@ -6,19 +6,18 @@ import uuid as uuid_  # noqa: F401  # pylint: disable=unused-import
 
 import sqlalchemy as sa  # noqa: F401  # pylint: disable=unused-import
 
-from coaster.db import db
 from coaster.gfm import markdown
 from coaster.sqlalchemy import BaseMixin, MarkdownColumn
 
-from .test_sqlalchemy_models import app1, app2
+from .test_sqlalchemy_models import app1, app2, db
 
 
-class MarkdownData(BaseMixin, db.Model):
+class MarkdownData(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'md_data'
     value = MarkdownColumn('value', nullable=False)
 
 
-class MarkdownHtmlData(BaseMixin, db.Model):
+class MarkdownHtmlData(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'md_html_data'
     value = MarkdownColumn('value', nullable=False, options={'html': True})
 
@@ -27,7 +26,7 @@ def fake_markdown(text):
     return 'fake-markdown'
 
 
-class FakeMarkdownData(BaseMixin, db.Model):
+class FakeMarkdownData(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'fake_md_data'
     value = MarkdownColumn('value', nullable=False, markdown=fake_markdown)
 

--- a/tests/test_sqlalchemy_models.py
+++ b/tests/test_sqlalchemy_models.py
@@ -7,6 +7,7 @@ import typing as t  # noqa: F401  # pylint: disable=unused-import
 import unittest
 import uuid as uuid_
 
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.orm import relationship, synonym
@@ -19,7 +20,6 @@ from werkzeug.routing import BuildError
 from pytz import utc
 import pytest
 
-from coaster.db import db
 from coaster.sqlalchemy import (
     BaseIdNameMixin,
     BaseMixin,
@@ -45,26 +45,27 @@ app1.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app2 = Flask(__name__)
 app2.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://localhost/coaster_test'
 app2.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+db = SQLAlchemy()
 db.init_app(app1)
 db.init_app(app2)
-login_manager = LoginManager(app1)
+LoginManager(app1)
 LoginManager(app2)
 
 
 # --- Models ---------------------------------------------------------------------------
 
 
-class TimestampNaive(BaseMixin, db.Model):
+class TimestampNaive(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'timestamp_naive'
     __with_timezone__ = False
 
 
-class TimestampAware(BaseMixin, db.Model):
+class TimestampAware(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'timestamp_aware'
     __with_timezone__ = True
 
 
-class Container(BaseMixin, db.Model):
+class Container(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'container'
     name = sa.Column(sa.Unicode(80), nullable=True)
     title = sa.Column(sa.Unicode(80), nullable=True)
@@ -72,7 +73,7 @@ class Container(BaseMixin, db.Model):
     content = sa.Column(sa.Unicode(250))
 
 
-class UnnamedDocument(BaseMixin, db.Model):
+class UnnamedDocument(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'unnamed_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
     container = relationship(Container)
@@ -80,7 +81,7 @@ class UnnamedDocument(BaseMixin, db.Model):
     content = sa.Column(sa.Unicode(250))
 
 
-class NamedDocument(BaseNameMixin, db.Model):
+class NamedDocument(BaseNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'named_document'
     reserved_names = ['new']
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
@@ -89,7 +90,7 @@ class NamedDocument(BaseNameMixin, db.Model):
     content = sa.Column(sa.Unicode(250))
 
 
-class NamedDocumentBlank(BaseNameMixin, db.Model):
+class NamedDocumentBlank(BaseNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'named_document_blank'
     __name_blank_allowed__ = True
     reserved_names = ['new']
@@ -99,7 +100,7 @@ class NamedDocumentBlank(BaseNameMixin, db.Model):
     content = sa.Column(sa.Unicode(250))
 
 
-class ScopedNamedDocument(BaseScopedNameMixin, db.Model):
+class ScopedNamedDocument(BaseScopedNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'scoped_named_document'
     reserved_names = ['new']
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
@@ -110,7 +111,7 @@ class ScopedNamedDocument(BaseScopedNameMixin, db.Model):
     __table_args__ = (sa.UniqueConstraint('container_id', 'name'),)
 
 
-class IdNamedDocument(BaseIdNameMixin, db.Model):
+class IdNamedDocument(BaseIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'id_named_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
     container = relationship(Container)
@@ -118,7 +119,7 @@ class IdNamedDocument(BaseIdNameMixin, db.Model):
     content = sa.Column(sa.Unicode(250))
 
 
-class ScopedIdDocument(BaseScopedIdMixin, db.Model):
+class ScopedIdDocument(BaseScopedIdMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'scoped_id_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
     container = relationship(Container)
@@ -128,7 +129,7 @@ class ScopedIdDocument(BaseScopedIdMixin, db.Model):
     __table_args__ = (sa.UniqueConstraint('container_id', 'url_id'),)
 
 
-class ScopedIdNamedDocument(BaseScopedIdNameMixin, db.Model):
+class ScopedIdNamedDocument(BaseScopedIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'scoped_id_named_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
     container = relationship(Container)
@@ -138,7 +139,7 @@ class ScopedIdNamedDocument(BaseScopedIdNameMixin, db.Model):
     __table_args__ = (sa.UniqueConstraint('container_id', 'url_id'),)
 
 
-class UnlimitedName(BaseNameMixin, db.Model):
+class UnlimitedName(BaseNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'unlimited_name'
     __name_length__ = __title_length__ = None
 
@@ -148,7 +149,7 @@ class UnlimitedName(BaseNameMixin, db.Model):
         return "Custom1: " + self.title
 
 
-class UnlimitedScopedName(BaseScopedNameMixin, db.Model):
+class UnlimitedScopedName(BaseScopedNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'unlimited_scoped_name'
     __name_length__ = __title_length__ = None
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
@@ -162,7 +163,7 @@ class UnlimitedScopedName(BaseScopedNameMixin, db.Model):
         return "Custom2: " + self.title
 
 
-class UnlimitedIdName(BaseIdNameMixin, db.Model):
+class UnlimitedIdName(BaseIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'unlimited_id_name'
     __name_length__ = __title_length__ = None
 
@@ -172,7 +173,7 @@ class UnlimitedIdName(BaseIdNameMixin, db.Model):
         return "Custom3: " + self.title
 
 
-class UnlimitedScopedIdName(BaseScopedIdNameMixin, db.Model):
+class UnlimitedScopedIdName(BaseScopedIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'unlimited_scoped_id_name'
     __name_length__ = __title_length__ = None
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
@@ -186,18 +187,18 @@ class UnlimitedScopedIdName(BaseScopedIdNameMixin, db.Model):
         return "Custom4: " + self.title
 
 
-class User(BaseMixin, db.Model):
+class User(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'user'
     username = sa.Column(sa.Unicode(80), nullable=False)
 
 
-class MyData(db.Model):
+class MyData(db.Model):  # type: ignore[name-defined]
     __tablename__ = 'my_data'
     id = sa.Column(sa.Integer, primary_key=True)  # noqa: A003
     data = sa.Column(JsonDict)
 
 
-class MyUrlModel(db.Model):
+class MyUrlModel(db.Model):  # type: ignore[name-defined]
     __tablename__ = 'my_url'
     id = sa.Column(sa.Integer, primary_key=True)  # noqa: A003
     url = sa.Column(UrlType)  # type: ignore[var-annotated]
@@ -214,23 +215,23 @@ class MyUrlModel(db.Model):
     )
 
 
-class NonUuidKey(BaseMixin, db.Model):
+class NonUuidKey(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'non_uuid_key'
     __uuid_primary_key__ = False
 
 
-class UuidKey(BaseMixin, db.Model):
+class UuidKey(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_key'
     __uuid_primary_key__ = True
 
 
-class UuidKeyNoDefault(BaseMixin, db.Model):
+class UuidKeyNoDefault(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_key_no_default'
     __uuid_primary_key__ = True
     id = db.Column(UUIDType(binary=False), primary_key=True)  # noqa: A003
 
 
-class UuidForeignKey1(BaseMixin, db.Model):
+class UuidForeignKey1(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_foreign_key1'
     __uuid_primary_key__ = False
     uuidkey_id: sa.Column[postgresql.UUID] = sa.Column(  # type: ignore[call-overload]
@@ -239,7 +240,7 @@ class UuidForeignKey1(BaseMixin, db.Model):
     uuidkey = relationship(UuidKey)
 
 
-class UuidForeignKey2(BaseMixin, db.Model):
+class UuidForeignKey2(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_foreign_key2'
     __uuid_primary_key__ = True
     uuidkey_id: sa.Column[postgresql.UUID] = sa.Column(  # type: ignore[call-overload]
@@ -248,36 +249,36 @@ class UuidForeignKey2(BaseMixin, db.Model):
     uuidkey = relationship(UuidKey)
 
 
-class UuidIdName(BaseIdNameMixin, db.Model):
+class UuidIdName(BaseIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_id_name'
     __uuid_primary_key__ = True
 
 
-class UuidIdNameMixin(UuidMixin, BaseIdNameMixin, db.Model):
+class UuidIdNameMixin(UuidMixin, BaseIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_id_name_mixin'
     __uuid_primary_key__ = True
 
 
-class UuidIdNameSecondary(UuidMixin, BaseIdNameMixin, db.Model):
+class UuidIdNameSecondary(UuidMixin, BaseIdNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_id_name_secondary'
     __uuid_primary_key__ = False
 
 
-class NonUuidMixinKey(UuidMixin, BaseMixin, db.Model):
+class NonUuidMixinKey(UuidMixin, BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'non_uuid_mixin_key'
     __uuid_primary_key__ = False
 
 
-class UuidMixinKey(UuidMixin, BaseMixin, db.Model):
+class UuidMixinKey(UuidMixin, BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_mixin_key'
     __uuid_primary_key__ = True
 
 
-class ParentForPrimary(BaseMixin, db.Model):
+class ParentForPrimary(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'parent_for_primary'
 
 
-class ChildForPrimary(BaseMixin, db.Model):
+class ChildForPrimary(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'child_for_primary'
     parent_for_primary_id = sa.Column(  # type: ignore[call-overload]
         sa.Integer, sa.ForeignKey('parent_for_primary.id'), nullable=False
@@ -300,7 +301,7 @@ parent_child_primary = db.Model.metadata.tables[
 ]
 
 
-class DefaultValue(BaseMixin, db.Model):
+class DefaultValue(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'default_value'
     value = db.Column(db.Unicode(100), default='default')
 

--- a/tests/test_sqlalchemy_models.py
+++ b/tests/test_sqlalchemy_models.py
@@ -43,7 +43,7 @@ app1 = Flask(__name__)
 app1.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
 app1.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app2 = Flask(__name__)
-app2.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql:///coaster_test'
+app2.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://localhost/coaster_test'
 app2.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app1)
 db.init_app(app2)
@@ -424,9 +424,8 @@ class TestCoasterModels(unittest.TestCase):
     def test_named_blank_disallowed(self):
         c1 = self.make_container()
         d1 = NamedDocument(title="Index", name="", container=c1)
-        d1.name = (
-            ""  # BaseNameMixin will always try to set a name. Explicitly blank it.
-        )
+        # BaseNameMixin will always try to set a name. Explicitly blank it.
+        d1.name = ""
         self.session.add(d1)
         with pytest.raises(IntegrityError):
             self.session.commit()
@@ -434,9 +433,8 @@ class TestCoasterModels(unittest.TestCase):
     def test_named_blank_allowed(self):
         c1 = self.make_container()
         d1 = NamedDocumentBlank(title="Index", name="", container=c1)
-        d1.name = (
-            ""  # BaseNameMixin will always try to set a name. Explicitly blank it.
-        )
+        # BaseNameMixin will always try to set a name. Explicitly blank it.
+        d1.name = ""
         self.session.add(d1)
         assert d1.name == ""
 

--- a/tests/test_sqlalchemy_models.py
+++ b/tests/test_sqlalchemy_models.py
@@ -74,7 +74,7 @@ class Container(BaseMixin, db.Model):
 class UnnamedDocument(BaseMixin, db.Model):
     __tablename__ = 'unnamed_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
+    container = relationship(Container)
 
     content = sa.Column(sa.Unicode(250))
 
@@ -83,7 +83,7 @@ class NamedDocument(BaseNameMixin, db.Model):
     __tablename__ = 'named_document'
     reserved_names = ['new']
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
+    container = relationship(Container)
 
     content = sa.Column(sa.Unicode(250))
 
@@ -93,7 +93,7 @@ class NamedDocumentBlank(BaseNameMixin, db.Model):
     __name_blank_allowed__ = True
     reserved_names = ['new']
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
+    container = relationship(Container)
 
     content = sa.Column(sa.Unicode(250))
 
@@ -102,8 +102,8 @@ class ScopedNamedDocument(BaseScopedNameMixin, db.Model):
     __tablename__ = 'scoped_named_document'
     reserved_names = ['new']
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
-    parent: Container = synonym('container')
+    container = relationship(Container)
+    parent = synonym('container')
 
     content = sa.Column(sa.Unicode(250))
     __table_args__ = (sa.UniqueConstraint('container_id', 'name'),)
@@ -112,7 +112,7 @@ class ScopedNamedDocument(BaseScopedNameMixin, db.Model):
 class IdNamedDocument(BaseIdNameMixin, db.Model):
     __tablename__ = 'id_named_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
+    container = relationship(Container)
 
     content = sa.Column(sa.Unicode(250))
 
@@ -120,8 +120,8 @@ class IdNamedDocument(BaseIdNameMixin, db.Model):
 class ScopedIdDocument(BaseScopedIdMixin, db.Model):
     __tablename__ = 'scoped_id_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
-    parent: Container = synonym('container')
+    container = relationship(Container)
+    parent = synonym('container')
 
     content = sa.Column(sa.Unicode(250))
     __table_args__ = (sa.UniqueConstraint('container_id', 'url_id'),)
@@ -130,8 +130,8 @@ class ScopedIdDocument(BaseScopedIdMixin, db.Model):
 class ScopedIdNamedDocument(BaseScopedIdNameMixin, db.Model):
     __tablename__ = 'scoped_id_named_document'
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
-    parent: Container = synonym('container')
+    container = relationship(Container)
+    parent = synonym('container')
 
     content = sa.Column(sa.Unicode(250))
     __table_args__ = (sa.UniqueConstraint('container_id', 'url_id'),)
@@ -143,6 +143,7 @@ class UnlimitedName(BaseNameMixin, db.Model):
 
     @property
     def title_for_name(self):
+        """Return title for make_name."""
         return "Custom1: " + self.title
 
 
@@ -150,12 +151,13 @@ class UnlimitedScopedName(BaseScopedNameMixin, db.Model):
     __tablename__ = 'unlimited_scoped_name'
     __name_length__ = __title_length__ = None
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
-    parent: Container = synonym('container')
+    container = relationship(Container)
+    parent = synonym('container')
     __table_args__ = (sa.UniqueConstraint('container_id', 'name'),)
 
     @property
     def title_for_name(self):
+        """Return title for make_name."""
         return "Custom2: " + self.title
 
 
@@ -165,6 +167,7 @@ class UnlimitedIdName(BaseIdNameMixin, db.Model):
 
     @property
     def title_for_name(self):
+        """Return title for make_name."""
         return "Custom3: " + self.title
 
 
@@ -172,12 +175,13 @@ class UnlimitedScopedIdName(BaseScopedIdNameMixin, db.Model):
     __tablename__ = 'unlimited_scoped_id_name'
     __name_length__ = __title_length__ = None
     container_id = sa.Column(sa.Integer, sa.ForeignKey('container.id'))
-    container: Container = relationship(Container)
-    parent: Container = synonym('container')
+    container = relationship(Container)
+    parent = synonym('container')
     __table_args__ = (sa.UniqueConstraint('container_id', 'url_id'),)
 
     @property
     def title_for_name(self):
+        """Return title for make_name."""
         return "Custom4: " + self.title
 
 
@@ -228,15 +232,19 @@ class UuidKeyNoDefault(BaseMixin, db.Model):
 class UuidForeignKey1(BaseMixin, db.Model):
     __tablename__ = 'uuid_foreign_key1'
     __uuid_primary_key__ = False
-    uuidkey_id: sa.Column[postgresql.UUID] = sa.Column(None, sa.ForeignKey('uuid_key.id'))  # type: ignore[call-overload]
-    uuidkey: UuidKey = relationship(UuidKey)
+    uuidkey_id: sa.Column[postgresql.UUID] = sa.Column(  # type: ignore[call-overload]
+        None, sa.ForeignKey('uuid_key.id')
+    )
+    uuidkey = relationship(UuidKey)
 
 
 class UuidForeignKey2(BaseMixin, db.Model):
     __tablename__ = 'uuid_foreign_key2'
     __uuid_primary_key__ = True
-    uuidkey_id: sa.Column[postgresql.UUID] = sa.Column(None, sa.ForeignKey('uuid_key.id'))  # type: ignore[call-overload]
-    uuidkey: UuidKey = relationship(UuidKey)
+    uuidkey_id: sa.Column[postgresql.UUID] = sa.Column(  # type: ignore[call-overload]
+        None, sa.ForeignKey('uuid_key.id')
+    )
+    uuidkey = relationship(UuidKey)
 
 
 class UuidIdName(BaseIdNameMixin, db.Model):
@@ -327,7 +335,7 @@ class TestCoasterModels(unittest.TestCase):
         c = self.make_container()
         assert c.id is None
         self.session.commit()
-        self.assertEqual(c.id, 1)
+        assert c.id == 1
 
     def test_timestamp(self):
         now1 = self.session.query(sa.func.utcnow()).scalar()
@@ -346,15 +354,13 @@ class TestCoasterModels(unittest.TestCase):
         # 1. utcnow will have timezone in PostgreSQL, but not in SQLite
         # 2. columns will have timezone iff PostgreSQL and the model has
         #    __with_timezone__ = True
-        self.assertNotEqual(
-            now1.replace(tzinfo=None), c.created_at.replace(tzinfo=None)
-        )
+        assert now1.replace(tzinfo=None) != c.created_at.replace(tzinfo=None)
         assert now1.replace(tzinfo=None) < c.created_at.replace(tzinfo=None)
         assert now2.replace(tzinfo=None) > c.created_at.replace(tzinfo=None)
         sleep(1)
         c.content = "updated"
         self.session.commit()
-        self.assertNotEqual(c.updated_at, u)
+        assert c.updated_at != u
         assert c.updated_at.replace(tzinfo=None) > now2.replace(tzinfo=None)
         assert c.updated_at > c.created_at
         assert c.updated_at > u
@@ -364,8 +370,8 @@ class TestCoasterModels(unittest.TestCase):
         d = UnnamedDocument(content="hello", container=c)
         self.session.add(d)
         self.session.commit()
-        self.assertEqual(c.id, 1)
-        self.assertEqual(d.id, 1)
+        assert c.id == 1
+        assert d.id == 1
 
     def test_named(self):
         """Named documents have globally unique names."""

--- a/tests/test_sqlalchemy_models.py
+++ b/tests/test_sqlalchemy_models.py
@@ -379,29 +379,29 @@ class TestCoasterModels(unittest.TestCase):
         d1 = NamedDocument(title="Hello", content="World", container=c1)
         self.session.add(d1)
         self.session.commit()
-        self.assertEqual(d1.name, 'hello')
-        self.assertEqual(NamedDocument.get('hello'), d1)
+        assert d1.name == 'hello'
+        assert NamedDocument.get('hello') == d1
 
         c2 = self.make_container()
         d2 = NamedDocument(title="Hello", content="Again", container=c2)
         self.session.add(d2)
         self.session.commit()
-        self.assertEqual(d2.name, 'hello2')
+        assert d2.name == 'hello2'
 
         # test insert in BaseNameMixin's upsert
         d3 = NamedDocument.upsert('hello3', title='hello3', content='hello3')
         self.session.commit()
         d3_persisted = NamedDocument.get('hello3')
-        self.assertEqual(d3_persisted, d3)
-        self.assertEqual(d3_persisted.content, 'hello3')
+        assert d3_persisted == d3
+        assert d3_persisted.content == 'hello3'
 
         # test update in BaseNameMixin's upsert
         d4 = NamedDocument.upsert('hello3', title='hello4', content='hello4')
         d4.make_name()
         self.session.commit()
         d4_persisted = NamedDocument.get('hello4')
-        self.assertEqual(d4_persisted, d4)
-        self.assertEqual(d4_persisted.content, 'hello4')
+        assert d4_persisted == d4
+        assert d4_persisted.content == 'hello4'
 
         with pytest.raises(TypeError):
             NamedDocument.upsert(
@@ -427,7 +427,8 @@ class TestCoasterModels(unittest.TestCase):
             ""  # BaseNameMixin will always try to set a name. Explicitly blank it.
         )
         self.session.add(d1)
-        self.assertRaises(IntegrityError, self.session.commit)
+        with pytest.raises(IntegrityError):
+            self.session.commit()
 
     def test_named_blank_allowed(self):
         c1 = self.make_container()
@@ -436,7 +437,7 @@ class TestCoasterModels(unittest.TestCase):
             ""  # BaseNameMixin will always try to set a name. Explicitly blank it.
         )
         self.session.add(d1)
-        self.assertEqual(d1.name, "")
+        assert d1.name == ""
 
     def test_scoped_named(self):
         """Scoped named documents have names unique to their containers."""
@@ -446,22 +447,22 @@ class TestCoasterModels(unittest.TestCase):
         u = User(username='foo')
         self.session.add(d1)
         self.session.commit()
-        self.assertEqual(ScopedNamedDocument.get(c1, 'hello'), d1)
-        self.assertEqual(d1.name, 'hello')
-        self.assertEqual(d1.permissions(actor=u), set())
-        self.assertEqual(d1.permissions(actor=u, inherited={'view'}), {'view'})
+        assert ScopedNamedDocument.get(c1, 'hello') == d1
+        assert d1.name == 'hello'
+        assert d1.permissions(actor=u) == set()
+        assert d1.permissions(actor=u, inherited={'view'}) == {'view'}
 
         d2 = ScopedNamedDocument(title="Hello", content="Again", container=c1)
         self.session.add(d2)
         self.session.commit()
-        self.assertEqual(d2.name, 'hello2')
+        assert d2.name == 'hello2'
 
         c2 = self.make_container()
         self.session.commit()
         d3 = ScopedNamedDocument(title="Hello", content="Once More", container=c2)
         self.session.add(d3)
         self.session.commit()
-        self.assertEqual(d3.name, 'hello')
+        assert d3.name == 'hello'
 
         # test insert in BaseScopedNameMixin's upsert
         d4 = ScopedNamedDocument.upsert(
@@ -469,8 +470,8 @@ class TestCoasterModels(unittest.TestCase):
         )
         self.session.commit()
         d4_persisted = ScopedNamedDocument.get(c1, 'hello4')
-        self.assertEqual(d4_persisted, d4)
-        self.assertEqual(d4_persisted.content, 'scoped named doc')
+        assert d4_persisted == d4
+        assert d4_persisted.content == 'scoped named doc'
 
         # test update in BaseScopedNameMixin's upsert
         d5 = ScopedNamedDocument.upsert(
@@ -479,8 +480,8 @@ class TestCoasterModels(unittest.TestCase):
         d5.make_name()
         self.session.commit()
         d5_persisted = ScopedNamedDocument.get(c2, 'hello5')
-        self.assertEqual(d5_persisted, d5)
-        self.assertEqual(d5_persisted.content, 'scoped named doc')
+        assert d5_persisted == d5
+        assert d5_persisted.content == 'scoped named doc'
 
         with pytest.raises(TypeError):
             ScopedNamedDocument.upsert(
@@ -506,17 +507,17 @@ class TestCoasterModels(unittest.TestCase):
         c1 = self.make_container()
         self.session.commit()
         d1 = ScopedNamedDocument(title="Hello", content="World", container=c1)
-        self.assertEqual(d1.short_title, "Hello")
+        assert d1.short_title == "Hello"
 
         c1.title = "Container"
         d1.title = "Container Contained"
-        self.assertEqual(d1.short_title, "Contained")
+        assert d1.short_title == "Contained"
 
         d1.title = "Container: Contained"
-        self.assertEqual(d1.short_title, "Contained")
+        assert d1.short_title == "Contained"
 
         d1.title = "Container - Contained"
-        self.assertEqual(d1.short_title, "Contained")
+        assert d1.short_title == "Contained"
 
     def test_id_named(self):
         """Documents with a global id in the URL"""
@@ -524,18 +525,18 @@ class TestCoasterModels(unittest.TestCase):
         d1 = IdNamedDocument(title="Hello", content="World", container=c1)
         self.session.add(d1)
         self.session.commit()
-        self.assertEqual(d1.url_name, '1-hello')
+        assert d1.url_name == '1-hello'
 
         d2 = IdNamedDocument(title="Hello", content="Again", container=c1)
         self.session.add(d2)
         self.session.commit()
-        self.assertEqual(d2.url_name, '2-hello')
+        assert d2.url_name == '2-hello'
 
         c2 = self.make_container()
         d3 = IdNamedDocument(title="Hello", content="Once More", container=c2)
         self.session.add(d3)
         self.session.commit()
-        self.assertEqual(d3.url_name, '3-hello')
+        assert d3.url_name == '3-hello'
 
     def test_scoped_id(self):
         """Documents with a container-specific id in the URL"""
@@ -544,26 +545,26 @@ class TestCoasterModels(unittest.TestCase):
         u = User(username="foo")
         self.session.add(d1)
         self.session.commit()
-        self.assertEqual(ScopedIdDocument.get(c1, d1.url_id), d1)
-        self.assertEqual(d1.permissions(actor=u, inherited={'view'}), {'view'})
-        self.assertEqual(d1.permissions(actor=u), set())
+        assert ScopedIdDocument.get(c1, d1.url_id) == d1
+        assert d1.permissions(actor=u, inherited={'view'}) == {'view'}
+        assert d1.permissions(actor=u) == set()
 
         d2 = ScopedIdDocument(content="New document", container=c1)
         self.session.add(d2)
         self.session.commit()
-        self.assertEqual(d1.url_id, 1)
-        self.assertEqual(d2.url_id, 2)
+        assert d1.url_id == 1
+        assert d2.url_id == 2
 
         c2 = self.make_container()
         d3 = ScopedIdDocument(content="Once More", container=c2)
         self.session.add(d3)
         self.session.commit()
-        self.assertEqual(d3.url_id, 1)
+        assert d3.url_id == 1
 
         d4 = ScopedIdDocument(content="Third", container=c1)
         self.session.add(d4)
         self.session.commit()
-        self.assertEqual(d4.url_id, 3)
+        assert d4.url_id == 3
 
     def test_scoped_id_named(self):
         """Documents with a container-specific id and name in the URL"""
@@ -571,57 +572,59 @@ class TestCoasterModels(unittest.TestCase):
         d1 = ScopedIdNamedDocument(title="Hello", content="World", container=c1)
         self.session.add(d1)
         self.session.commit()
-        self.assertEqual(d1.url_name, '1-hello')
-        self.assertEqual(
-            d1.url_name, d1.url_id_name
-        )  # url_name is now an alias for url_id_name
-        self.assertEqual(ScopedIdNamedDocument.get(c1, d1.url_id), d1)
+        assert d1.url_name == '1-hello'
+        assert d1.url_name == d1.url_id_name  # url_name is now an alias for url_id_name
+        assert ScopedIdNamedDocument.get(c1, d1.url_id) == d1
 
         d2 = ScopedIdNamedDocument(
             title="Hello again", content="New name", container=c1
         )
         self.session.add(d2)
         self.session.commit()
-        self.assertEqual(d2.url_name, '2-hello-again')
+        assert d2.url_name == '2-hello-again'
 
         c2 = self.make_container()
         d3 = ScopedIdNamedDocument(title="Hello", content="Once More", container=c2)
         self.session.add(d3)
         self.session.commit()
-        self.assertEqual(d3.url_name, '1-hello')
+        assert d3.url_name == '1-hello'
 
         d4 = ScopedIdNamedDocument(title="Hello", content="Third", container=c1)
         self.session.add(d4)
         self.session.commit()
-        self.assertEqual(d4.url_name, '3-hello')
+        assert d4.url_name == '3-hello'
 
         # Queries work as well
         qd1 = ScopedIdNamedDocument.query.filter_by(
             container=c1, url_name=d1.url_name
         ).first()
-        self.assertEqual(qd1, d1)
+        assert qd1 == d1
         qd2 = ScopedIdNamedDocument.query.filter_by(
             container=c1, url_id_name=d2.url_id_name
         ).first()
-        self.assertEqual(qd2, d2)
+        assert qd2 == d2
 
     def test_scoped_id_without_parent(self):
         d1 = ScopedIdDocument(content="Hello")
         self.session.add(d1)
-        self.assertRaises(IntegrityError, self.session.commit)
+        with pytest.raises(IntegrityError):
+            self.session.commit()
         self.session.rollback()
         d2 = ScopedIdDocument(content="Hello again")
         self.session.add(d2)
-        self.assertRaises(IntegrityError, self.session.commit)
+        with pytest.raises(IntegrityError):
+            self.session.commit()
 
     def test_scoped_named_without_parent(self):
         d1 = ScopedNamedDocument(title="Hello", content="World")
         self.session.add(d1)
-        self.assertRaises(IntegrityError, self.session.commit)
+        with pytest.raises(IntegrityError):
+            self.session.commit()
         self.session.rollback()
         d2 = ScopedIdNamedDocument(title="Hello", content="World")
         self.session.add(d2)
-        self.assertRaises(IntegrityError, self.session.commit)
+        with pytest.raises(IntegrityError):
+            self.session.commit()
 
     def test_reserved_name(self):
         c = self.make_container()
@@ -630,12 +633,12 @@ class TestCoasterModels(unittest.TestCase):
         # 'new' is reserved in the class definition. Also reserve new2 here and
         # confirm we get new3 for the name
         d1.make_name(reserved=['new2'])
-        self.assertEqual(d1.name, 'new3')
+        assert d1.name == 'new3'
         d2 = ScopedNamedDocument(container=c, title="New")
         # 'new' is reserved in the class definition. Also reserve new2 here and
         # confirm we get new3 for the name
         d2.make_name(reserved=['new2'])
-        self.assertEqual(d2.name, 'new3')
+        assert d2.name == 'new3'
 
         # Now test again after adding to session. Results should be identical
         self.session.add(d1)
@@ -643,9 +646,9 @@ class TestCoasterModels(unittest.TestCase):
         self.session.commit()
 
         d1.make_name(reserved=['new2'])
-        self.assertEqual(d1.name, 'new3')
+        assert d1.name == 'new3'
         d2.make_name(reserved=['new2'])
-        self.assertEqual(d2.name, 'new3')
+        assert d2.name == 'new3'
 
     def test_named_auto(self):
         """
@@ -744,10 +747,11 @@ class TestCoasterModels(unittest.TestCase):
         self.session.commit()
         # Test for __setitem__
         m1.data['value'] = 'bar'
-        self.assertEqual(m1.data['value'], 'bar')
+        assert m1.data['value'] == 'bar'
         del m1.data['value']
-        self.assertEqual(m1.data, {})
-        self.assertRaises(ValueError, MyData, data='NonDict')
+        assert m1.data == {}
+        with pytest.raises(ValueError):
+            MyData(data='NonDict')
 
     def test_urltype(self):
         m1 = MyUrlModel(
@@ -831,9 +835,10 @@ class TestCoasterModels(unittest.TestCase):
         self.session.add(c2)
         self.session.commit()
 
-        self.assertEqual(Container.query.filter_by(name='c1').one_or_none(), c1)
+        assert Container.query.filter_by(name='c1').one_or_none() == c1
         assert Container.query.filter_by(name='c3').one_or_none() is None
-        self.assertRaises(MultipleResultsFound, Container.query.one_or_none)
+        with pytest.raises(MultipleResultsFound):
+            Container.query.one_or_none()
 
     def test_failsafe_add(self):
         """
@@ -867,9 +872,8 @@ class TestCoasterModels(unittest.TestCase):
         failsafe_add passes through errors occuring from bad data
         """
         d1 = NamedDocument(name='missing_title')
-        self.assertRaises(
-            IntegrityError, failsafe_add, self.session, d1, name='missing_title'
-        )
+        with pytest.raises(IntegrityError):
+            failsafe_add(self.session, d1, name='missing_title')
 
     def test_failsafe_add_silent_fail(self):
         """
@@ -877,7 +881,7 @@ class TestCoasterModels(unittest.TestCase):
         when no filters are provided
         """
         d1 = NamedDocument(name='missing_title')
-        self.assertIsNone(failsafe_add(self.session, d1))
+        assert failsafe_add(self.session, d1) is None
 
     def test_uuid_key(self):
         """
@@ -890,7 +894,7 @@ class TestCoasterModels(unittest.TestCase):
         self.session.commit()
         assert isinstance(u1.id, uuid_.UUID)
         assert isinstance(u2.id, uuid_.UUID)
-        self.assertNotEqual(u1.id, u2.id)
+        assert u1.id != u2.id
 
         fk1 = UuidForeignKey1(uuidkey=u1)
         fk2 = UuidForeignKey2(uuidkey=u2)
@@ -898,12 +902,12 @@ class TestCoasterModels(unittest.TestCase):
         db.session.add(fk2)
         db.session.commit()
 
-        self.assertIs(fk1.uuidkey, u1)
-        self.assertIs(fk2.uuidkey, u2)
+        assert fk1.uuidkey is u1
+        assert fk2.uuidkey is u2
         assert isinstance(fk1.uuidkey_id, uuid_.UUID)
         assert isinstance(fk2.uuidkey_id, uuid_.UUID)
-        self.assertEqual(fk1.uuidkey_id, u1.id)
-        self.assertEqual(fk2.uuidkey_id, u2.id)
+        assert fk1.uuidkey_id == u1.id
+        assert fk2.uuidkey_id == u2.id
 
     def test_uuid_url_id(self):
         """
@@ -930,43 +934,43 @@ class TestCoasterModels(unittest.TestCase):
         i3 = u3.uuid
         i4 = u4.uuid
 
-        self.assertEqual(u1.url_id, str(i1))
+        assert u1.url_id == str(i1)
 
-        self.assertIsInstance(i2, uuid_.UUID)
-        self.assertEqual(u2.url_id, i2.hex)
-        self.assertEqual(len(u2.url_id), 32)  # This is a 32-byte hex representation
+        assert isinstance(i2, uuid_.UUID)
+        assert u2.url_id == i2.hex
+        assert len(u2.url_id) == 32  # This is a 32-byte hex representation
         assert '-' not in u2.url_id  # Without dashes
 
-        self.assertIsInstance(i3, uuid_.UUID)
-        self.assertEqual(u3.uuid_hex, i3.hex)
-        self.assertEqual(len(u3.uuid_hex), 32)  # This is a 32-byte hex representation
+        assert isinstance(i3, uuid_.UUID)
+        assert u3.uuid_hex == i3.hex
+        assert len(u3.uuid_hex) == 32  # This is a 32-byte hex representation
         assert '-' not in u3.uuid_hex  # Without dashes
 
-        self.assertIsInstance(i4, uuid_.UUID)
-        self.assertEqual(u4.uuid_hex, i4.hex)
-        self.assertEqual(len(u4.uuid_hex), 32)  # This is a 32-byte hex representation
+        assert isinstance(i4, uuid_.UUID)
+        assert u4.uuid_hex == i4.hex
+        assert len(u4.uuid_hex) == 32  # This is a 32-byte hex representation
         assert '-' not in u4.uuid_hex  # Without dashes
 
         # Querying against `url_id` redirects the query to
         # `id` (IdMixin) or `uuid` (UuidMixin).
 
         # With integer primary keys, `url_id` is simply a proxy for `id`
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidKey.url_id == 1).compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_key.id = 1",
+            )
+            == "non_uuid_key.id = 1"
         )
         # We don't check the data type here, leaving that to the engine
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidKey.url_id == '1').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_key.id = '1'",
+            )
+            == "non_uuid_key.id = '1'"
         )
 
         # With UUID primary keys, `url_id` casts the value into a UUID
@@ -977,45 +981,45 @@ class TestCoasterModels(unittest.TestCase):
         # with multiple renderings.
 
         # Hex UUID
-        self.assertEqual(
+        assert (
             str(
                 (UuidKey.url_id == '74d588574a7611e78c27c38403d0935c').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
         # Hex UUID with !=
-        self.assertEqual(
+        assert (
             str(
                 (UuidKey.url_id != '74d588574a7611e78c27c38403d0935c').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_key.id != '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_key.id != '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
         # Hex UUID with dashes
-        self.assertEqual(
+        assert (
             str(
                 (UuidKey.url_id == '74d58857-4a76-11e7-8c27-c38403d0935c').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
         # UUID object
-        self.assertEqual(
+        assert (
             str(
                 (
                     UuidKey.url_id == uuid_.UUID('74d58857-4a76-11e7-8c27-c38403d0935c')
                 ).compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
         # IN clause with mixed inputs, including an invalid input
-        self.assertEqual(
+        assert (
             str(
                 (
                     UuidKey.url_id.in_(
@@ -1028,35 +1032,35 @@ class TestCoasterModels(unittest.TestCase):
                 ).compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_key.id IN ('74d58857-4a76-11e7-8c27-c38403d0935c',"
-            " '74d58857-4a76-11e7-8c27-c38403d0935c')",
+            )
+            == "uuid_key.id IN ('74d58857-4a76-11e7-8c27-c38403d0935c',"
+            " '74d58857-4a76-11e7-8c27-c38403d0935c')"
         )
 
         # None value
-        self.assertEqual(
+        assert (
             str(
                 (UuidKey.url_id == None).compile(  # noqa: E711
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_key.id IS NULL",
+            )
+            == "uuid_key.id IS NULL"
         )
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidKey.url_id.is_(None)).compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_key.id IS NULL",
+            )
+            == "non_uuid_key.id IS NULL"
         )
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidMixinKey.uuid_hex == None).compile(  # noqa: E711
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_mixin_key.uuid IS NULL",
+            )
+            == "non_uuid_mixin_key.uuid IS NULL"
         )
 
         # Query returns False (or True) if given an invalid value
@@ -1068,35 +1072,35 @@ class TestCoasterModels(unittest.TestCase):
         assert bool(UuidMixinKey.url_id != 'garbage!') is True
 
         # Repeat against UuidMixin classes (with only hex keys for brevity)
-        self.assertEqual(
+        assert (
             str(
                 (
                     NonUuidMixinKey.uuid_hex == '74d588574a7611e78c27c38403d0935c'
                 ).compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_mixin_key.uuid = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "non_uuid_mixin_key.uuid = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
-        self.assertEqual(
+        assert (
             str(
                 (UuidMixinKey.uuid_hex == '74d588574a7611e78c27c38403d0935c').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_mixin_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_mixin_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
 
         # Running a database query with url_id works as expected.
         # This test should pass on both SQLite and PostgreSQL
         qu1 = NonUuidKey.query.filter_by(url_id=u1.url_id).first()
-        self.assertEqual(u1, qu1)
+        assert u1 == qu1
         qu2 = UuidKey.query.filter_by(url_id=u2.url_id).first()
-        self.assertEqual(u2, qu2)
+        assert u2 == qu2
         qu3 = NonUuidMixinKey.query.filter_by(url_id=u3.url_id).first()
-        self.assertEqual(u3, qu3)
+        assert u3 == qu3
         qu4 = UuidMixinKey.query.filter_by(url_id=u4.url_id).first()
-        self.assertEqual(u4, qu4)
+        assert u4 == qu4
 
     def test_uuid_buid_uuid_b58(self):
         """
@@ -1108,20 +1112,20 @@ class TestCoasterModels(unittest.TestCase):
         db.session.commit()
 
         # The `uuid` column contains a UUID
-        self.assertIsInstance(u1.uuid, uuid_.UUID)
-        self.assertIsInstance(u2.uuid, uuid_.UUID)
+        assert isinstance(u1.uuid, uuid_.UUID)
+        assert isinstance(u2.uuid, uuid_.UUID)
 
         # Test readbility of `buid` attribute
-        self.assertEqual(u1.buid, uuid_to_base64(u1.uuid))
-        self.assertEqual(len(u1.buid), 22)  # This is a 22-char B64 representation
-        self.assertEqual(u2.buid, uuid_to_base64(u2.uuid))
-        self.assertEqual(len(u2.buid), 22)  # This is a 22-char B64 representation
+        assert u1.buid == uuid_to_base64(u1.uuid)
+        assert len(u1.buid) == 22  # This is a 22-char B64 representation
+        assert u2.buid == uuid_to_base64(u2.uuid)
+        assert len(u2.buid) == 22  # This is a 22-char B64 representation
 
         # Test readbility of `uuid_b58` attribute
-        self.assertEqual(u1.uuid_b58, uuid_to_base58(u1.uuid))
-        self.assertIn(len(u1.uuid_b58), (21, 22))  # 21 or 22-char B58 representation
-        self.assertEqual(u2.uuid_b58, uuid_to_base58(u2.uuid))
-        self.assertIn(len(u2.uuid_b58), (21, 22))  # 21 or 22-char B58 representation
+        assert u1.uuid_b58 == uuid_to_base58(u1.uuid)
+        assert len(u1.uuid_b58) in (21, 22)  # 21 or 22-char B58 representation
+        assert u2.uuid_b58 == uuid_to_base58(u2.uuid)
+        assert len(u2.uuid_b58) in (21, 22)  # 21 or 22-char B58 representation
 
         # SQL queries against `buid` and `uuid_b58` cast the value into a UUID
         # and then query against `id` or ``uuid``
@@ -1130,77 +1134,77 @@ class TestCoasterModels(unittest.TestCase):
         # no engine is specified, and so casts them into a string
 
         # UuidMixin with integer primary key queries against the `uuid` column
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidMixinKey.buid == 'dNWIV0p2EeeMJ8OEA9CTXA').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_mixin_key.uuid = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "non_uuid_mixin_key.uuid = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
 
         # UuidMixin with UUID primary key queries against the `id` column
-        self.assertEqual(
+        assert (
             str(
                 (UuidMixinKey.buid == 'dNWIV0p2EeeMJ8OEA9CTXA').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_mixin_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_mixin_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
 
         # Repeat for `uuid_b58`
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidMixinKey.uuid_b58 == 'FRn1p6EnzbhydnssMnHqFZ').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_mixin_key.uuid = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "non_uuid_mixin_key.uuid = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
 
         # UuidMixin with UUID primary key queries against the `id` column
-        self.assertEqual(
+        assert (
             str(
                 (UuidMixinKey.uuid_b58 == 'FRn1p6EnzbhydnssMnHqFZ').compile(
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_mixin_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'",
+            )
+            == "uuid_mixin_key.id = '74d58857-4a76-11e7-8c27-c38403d0935c'"
         )
 
         # All queries work for None values as well
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidMixinKey.buid == None).compile(  # noqa: E711
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_mixin_key.uuid IS NULL",
+            )
+            == "non_uuid_mixin_key.uuid IS NULL"
         )
-        self.assertEqual(
+        assert (
             str(
                 (UuidMixinKey.buid == None).compile(  # noqa: E711
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_mixin_key.id IS NULL",
+            )
+            == "uuid_mixin_key.id IS NULL"
         )
-        self.assertEqual(
+        assert (
             str(
                 (NonUuidMixinKey.uuid_b58 == None).compile(  # noqa: E711
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "non_uuid_mixin_key.uuid IS NULL",
+            )
+            == "non_uuid_mixin_key.uuid IS NULL"
         )
-        self.assertEqual(
+        assert (
             str(
                 (UuidMixinKey.uuid_b58 == None).compile(  # noqa: E711
                     dialect=postgresql.dialect(), compile_kwargs={'literal_binds': True}
                 )
-            ),
-            "uuid_mixin_key.id IS NULL",
+            )
+            == "uuid_mixin_key.id IS NULL"
         )
 
         # Query returns False (or True) if given an invalid value
@@ -1237,39 +1241,39 @@ class TestCoasterModels(unittest.TestCase):
         db.session.add_all([u1, u2, u3])
         db.session.commit()
 
-        self.assertEqual(u1.url_id, '74d588574a7611e78c27c38403d0935c')
-        self.assertEqual(u1.url_id_name, '74d588574a7611e78c27c38403d0935c-test')
+        assert u1.url_id == '74d588574a7611e78c27c38403d0935c'
+        assert u1.url_id_name == '74d588574a7611e78c27c38403d0935c-test'
         # No uuid_b58 without UuidMixin
         with pytest.raises(AttributeError):
-            self.assertEqual(u1.url_name_uuid_b58, 'test-FRn1p6EnzbhydnssMnHqFZ')
-        self.assertEqual(u2.uuid_hex, '74d588574a7611e78c27c38403d0935c')
-        self.assertEqual(u2.url_id_name, '74d588574a7611e78c27c38403d0935c-test')
-        self.assertEqual(u2.url_name_uuid_b58, 'test-FRn1p6EnzbhydnssMnHqFZ')
-        self.assertEqual(u3.uuid_hex, '74d588574a7611e78c27c38403d0935c')
+            assert u1.url_name_uuid_b58 == 'test-FRn1p6EnzbhydnssMnHqFZ'
+        assert u2.uuid_hex == '74d588574a7611e78c27c38403d0935c'
+        assert u2.url_id_name == '74d588574a7611e78c27c38403d0935c-test'
+        assert u2.url_name_uuid_b58 == 'test-FRn1p6EnzbhydnssMnHqFZ'
+        assert u3.uuid_hex == '74d588574a7611e78c27c38403d0935c'
         # url_id_name in BaseIdNameMixin uses the id column, not the uuid column
-        self.assertEqual(u3.url_id_name, '1-test')
-        self.assertEqual(u3.url_name_uuid_b58, 'test-FRn1p6EnzbhydnssMnHqFZ')
+        assert u3.url_id_name == '1-test'
+        assert u3.url_name_uuid_b58 == 'test-FRn1p6EnzbhydnssMnHqFZ'
 
         # url_name is legacy
-        self.assertEqual(u1.url_id_name, u1.url_name)
-        self.assertEqual(u2.url_id_name, u2.url_name)
-        self.assertEqual(u3.url_id_name, u3.url_name)
+        assert u1.url_id_name == u1.url_name
+        assert u2.url_id_name == u2.url_name
+        assert u3.url_id_name == u3.url_name
 
         qu1 = UuidIdName.query.filter_by(url_id_name=u1.url_id_name).first()
-        self.assertEqual(qu1, u1)
+        assert qu1 == u1
         qu2 = UuidIdNameMixin.query.filter_by(url_id_name=u2.url_id_name).first()
-        self.assertEqual(qu2, u2)
+        assert qu2 == u2
         qu3 = UuidIdNameSecondary.query.filter_by(url_id_name=u3.url_id_name).first()
-        self.assertEqual(qu3, u3)
+        assert qu3 == u3
 
         q58u2 = UuidIdNameMixin.query.filter_by(
             url_name_uuid_b58=u2.url_name_uuid_b58
         ).first()
-        self.assertEqual(q58u2, u2)
+        assert q58u2 == u2
         q58u3 = UuidIdNameSecondary.query.filter_by(
             url_name_uuid_b58=u3.url_name_uuid_b58
         ).first()
-        self.assertEqual(q58u3, u3)
+        assert q58u3 == u3
 
     def test_uuid_default(self):
         """
@@ -1283,24 +1287,24 @@ class TestCoasterModels(unittest.TestCase):
         uuidm_yes = UuidMixinKey()
         # Non-UUID primary keys are not automatically generated
         u1 = uuid_no.id
-        self.assertIsNone(u1)
+        assert u1 is None
         # However, UUID keys are generated even before adding to session
         u2 = uuid_yes.id
-        self.assertIsInstance(u2, uuid_.UUID)
+        assert isinstance(u2, uuid_.UUID)
         # Once generated, the key remains stable
         u3 = uuid_yes.id
-        self.assertEqual(u2, u3)
+        assert u2 == u3
         # A UUID primary key with a custom column with no default doesn't break
         # the default generator
         u4 = uuid_no_default.id
-        self.assertIsNone(u4)
+        assert u4 is None
 
         # UuidMixin works likewise
         um1 = uuidm_no.uuid
-        self.assertIsInstance(um1, uuid_.UUID)
+        assert isinstance(um1, uuid_.UUID)
         um2 = uuidm_yes.uuid  # This should generate uuidm_yes.id
-        self.assertIsInstance(um2, uuid_.UUID)
-        self.assertEqual(uuidm_yes.id, uuidm_yes.uuid)
+        assert isinstance(um2, uuid_.UUID)
+        assert uuidm_yes.id == uuidm_yes.uuid
 
     def test_parent_child_primary(self):
         """
@@ -1316,14 +1320,14 @@ class TestCoasterModels(unittest.TestCase):
         self.session.add_all([parent1, parent2, child1a, child1b, child2a, child2b])
         self.session.commit()
 
-        self.assertIsNone(parent1.primary_child)
-        self.assertIsNone(parent2.primary_child)
+        assert parent1.primary_child is None
+        assert parent2.primary_child is None
 
-        self.assertEqual(
+        assert (
             self.session.query(sa.func.count())
             .select_from(parent_child_primary)
-            .scalar(),
-            0,
+            .scalar()
+            == 0
         )
 
         parent1.primary_child = child1a
@@ -1332,48 +1336,48 @@ class TestCoasterModels(unittest.TestCase):
         self.session.commit()
 
         # The change has been committed to the database
-        self.assertEqual(
+        assert (
             self.session.query(sa.func.count())
             .select_from(parent_child_primary)
-            .scalar(),
-            2,
+            .scalar()
+            == 2
         )
         qparent1 = ParentForPrimary.query.get(parent1.id)
         qparent2 = ParentForPrimary.query.get(parent2.id)
 
-        self.assertEqual(qparent1.primary_child, child1a)
-        self.assertEqual(qparent2.primary_child, child2a)
+        assert qparent1.primary_child == child1a
+        assert qparent2.primary_child == child2a
 
         # # A parent can't have a default that is another's child
         with pytest.raises(ValueError):
             parent1.primary_child = child2b
 
         # The default hasn't changed despite the validation error
-        self.assertEqual(parent1.primary_child, child1a)
+        assert parent1.primary_child == child1a
 
         # Unsetting the default removes the relationship row,
         # but does not remove the child instance from the db
         parent1.primary_child = None
         self.session.commit()
-        self.assertEqual(
+        assert (
             self.session.query(sa.func.count())
             .select_from(parent_child_primary)
-            .scalar(),
-            1,
+            .scalar()
+            == 1
         )
-        self.assertIsNotNone(ChildForPrimary.query.get(child1a.id))
+        assert ChildForPrimary.query.get(child1a.id) is not None
 
         # Deleting a child also removes the corresponding relationship row
         # but not the parent
         self.session.delete(child2a)
         self.session.commit()
-        self.assertEqual(
+        assert (
             self.session.query(sa.func.count())
             .select_from(parent_child_primary)
-            .scalar(),
-            0,
+            .scalar()
+            == 0
         )
-        self.assertEqual(ParentForPrimary.query.count(), 2)
+        assert ParentForPrimary.query.count() == 2
 
     def test_auto_init_default(self):
         """
@@ -1384,28 +1388,28 @@ class TestCoasterModels(unittest.TestCase):
         d3 = DefaultValue()
         d4 = DefaultValue(value='not-default')
 
-        self.assertEqual(d1.value, 'default')
-        self.assertEqual(d1.value, 'default')  # Also works on second access
-        self.assertEqual(d2.value, 'not-default')
-        self.assertEqual(d3.value, 'default')
-        self.assertEqual(d4.value, 'not-default')
+        assert d1.value == 'default'
+        assert d1.value == 'default'  # Also works on second access
+        assert d2.value == 'not-default'
+        assert d3.value == 'default'
+        assert d4.value == 'not-default'
 
         d3.value = 'changed'
         d4.value = 'changed'
 
-        self.assertEqual(d3.value, 'changed')
-        self.assertEqual(d4.value, 'changed')
+        assert d3.value == 'changed'
+        assert d4.value == 'changed'
 
         db.session.add_all([d1, d2, d3, d4])
         db.session.commit()
 
         for d in DefaultValue.query.all():
             if d.id == d1.id:
-                self.assertEqual(d.value, 'default')
+                assert d.value == 'default'
             elif d.id == d2.id:
-                self.assertEqual(d.value, 'not-default')
+                assert d.value == 'not-default'
             elif d.id in (d3.id, d4.id):
-                self.assertEqual(d.value, 'changed')
+                assert d.value == 'changed'
 
 
 class TestCoasterModelsPG(TestCoasterModels):
@@ -1427,11 +1431,11 @@ class TestCoasterModelsPG(TestCoasterModels):
         self.session.commit()
 
         # The change has been committed to the database
-        self.assertEqual(
+        assert (
             self.session.query(sa.func.count())
             .select_from(parent_child_primary)
-            .scalar(),
-            1,
+            .scalar()
+            == 1
         )
         # Attempting a direct write to the db works for valid children and fails for invalid children
         self.session.execute(

--- a/tests/test_sqlalchemy_models.py
+++ b/tests/test_sqlalchemy_models.py
@@ -1,4 +1,5 @@
 """Test SQLAlchemy model mixins."""
+# pylint: disable=too-many-lines
 
 from datetime import datetime, timedelta
 from time import sleep

--- a/tests/test_sqlalchemy_registry.py
+++ b/tests/test_sqlalchemy_registry.py
@@ -8,9 +8,10 @@ import sqlalchemy as sa  # noqa: F401  # pylint: disable=unused-import
 
 import pytest
 
-from coaster.db import db
 from coaster.sqlalchemy import BaseMixin
 from coaster.sqlalchemy.registry import Registry
+
+from .test_sqlalchemy_models import db
 
 # --- Fixtures -------------------------------------------------------------------------
 
@@ -113,13 +114,13 @@ def registrymixin_models():
     # in the base RegistryMixin class.
 
     # Sample model 1
-    class RegistryTest1(BaseMixin, db.Model):
+    class RegistryTest1(BaseMixin, db.Model):  # type: ignore[name-defined]
         """Registry test model 1."""
 
         __tablename__ = 'registry_test1'
 
     # Sample model 2
-    class RegistryTest2(BaseMixin, db.Model):
+    class RegistryTest2(BaseMixin, db.Model):  # type: ignore[name-defined]
         """Registry test model 2."""
 
         __tablename__ = 'registry_test2'

--- a/tests/test_sqlalchemy_roles.py
+++ b/tests/test_sqlalchemy_roles.py
@@ -337,7 +337,7 @@ class MultiroleChild(BaseMixin, db.Model):
             'rel_lazy.user': {  # Maps to parent.rel_lazy[item].user
                 # Map role2 and role3, but explicitly ignore role1.
                 # Demonstrate mapping to multiple roles
-                'role2': ('parent_role2', 'parent_role2b', 'parent_role_shared'),
+                'role2': {'parent_role2', 'parent_role2b', 'parent_role_shared'},
                 'role3': {'parent_role3', 'parent_role3b', 'parent_role_shared'},
             },
         },

--- a/tests/test_sqlalchemy_roles.py
+++ b/tests/test_sqlalchemy_roles.py
@@ -17,7 +17,6 @@ from flask import Flask
 
 import pytest
 
-from coaster.db import db
 from coaster.sqlalchemy import (
     BaseMixin,
     BaseNameMixin,
@@ -30,6 +29,8 @@ from coaster.sqlalchemy import (
     with_roles,
 )
 from coaster.utils import InspectableSet
+
+from .test_sqlalchemy_models import db
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
@@ -64,7 +65,7 @@ class DeclaredAttrMixin:
     mixed_in4 = with_roles(mixed_in4, rw={'owner'})
 
 
-class RoleModel(DeclaredAttrMixin, RoleMixin, db.Model):
+class RoleModel(DeclaredAttrMixin, RoleMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'role_model'
 
     # Approach one, declare roles in advance.
@@ -109,7 +110,7 @@ class RoleModel(DeclaredAttrMixin, RoleMixin, db.Model):
         return roles
 
 
-class AutoRoleModel(RoleMixin, db.Model):
+class AutoRoleModel(RoleMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'auto_role_model'
 
     # This model doesn't specify __roles__. It only uses with_roles.
@@ -124,15 +125,15 @@ class AutoRoleModel(RoleMixin, db.Model):
     __json_datasets__ = ('default',)
 
 
-class BaseModel(BaseMixin, db.Model):
+class BaseModel(BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'base_model'
 
 
-class UuidModel(UuidMixin, BaseMixin, db.Model):
+class UuidModel(UuidMixin, BaseMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'uuid_model'
 
 
-class RelationshipChild(BaseNameMixin, db.Model):
+class RelationshipChild(BaseNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'relationship_child'
 
     parent_id = db.Column(None, db.ForeignKey('relationship_parent.id'), nullable=False)
@@ -144,7 +145,7 @@ class RelationshipChild(BaseNameMixin, db.Model):
     }
 
 
-class RelationshipParent(BaseNameMixin, db.Model):
+class RelationshipParent(BaseNameMixin, db.Model):  # type: ignore[name-defined]
     __tablename__ = 'relationship_parent'
 
     children_list = db.relationship(RelationshipChild, backref='parent')
@@ -196,7 +197,7 @@ RelationshipParent.children_names = DynamicAssociationProxy(
 )
 
 
-class RoleGrantMany(BaseMixin, db.Model):
+class RoleGrantMany(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model for granting roles to users in many-to-one and many-to-many relationships"""
 
     __tablename__ = 'role_grant_many'
@@ -207,7 +208,7 @@ class RoleGrantMany(BaseMixin, db.Model):
     }
 
 
-class RoleUser(BaseMixin, db.Model):
+class RoleUser(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model to represent a user who has roles"""
 
     __tablename__ = 'role_user'
@@ -223,7 +224,7 @@ class RoleUser(BaseMixin, db.Model):
     )
 
 
-class RoleGrantOne(BaseMixin, db.Model):
+class RoleGrantOne(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model for granting roles to users in a one-to-many relationship"""
 
     __tablename__ = 'role_grant_one'
@@ -232,7 +233,7 @@ class RoleGrantOne(BaseMixin, db.Model):
     user = with_roles(db.relationship(RoleUser), grants={'creator'})
 
 
-class RoleGrantSynonym(BaseMixin, db.Model):
+class RoleGrantSynonym(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model for granting roles to synonyms"""
 
     __tablename__ = 'role_grant_synonym'
@@ -243,7 +244,7 @@ class RoleGrantSynonym(BaseMixin, db.Model):
     altcol = db.synonym('datacol')
 
 
-class RoleMembership(BaseMixin, db.Model):
+class RoleMembership(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model that grants multiple roles"""
 
     __tablename__ = 'role_membership'
@@ -270,7 +271,7 @@ class RoleMembership(BaseMixin, db.Model):
         return roles
 
 
-class MultiroleParent(BaseMixin, db.Model):
+class MultiroleParent(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model to serve as a role granter to the child model"""
 
     __tablename__ = 'multirole_parent'
@@ -278,7 +279,7 @@ class MultiroleParent(BaseMixin, db.Model):
     user = with_roles(db.relationship(RoleUser), grants={'prole1', 'prole2'})
 
 
-class MultiroleDocument(BaseMixin, db.Model):
+class MultiroleDocument(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Test model that grants multiple roles via RoleMembership"""
 
     __tablename__ = 'multirole_document'
@@ -325,7 +326,7 @@ class MultiroleDocument(BaseMixin, db.Model):
     # The only way to make an entry there is via with_roles.
 
 
-class MultiroleChild(BaseMixin, db.Model):
+class MultiroleChild(BaseMixin, db.Model):  # type: ignore[name-defined]
     """Model that inherits roles from its parent"""
 
     __tablename__ = 'multirole_child'

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -5,9 +5,7 @@ from werkzeug.routing import BuildError
 
 import pytest
 
-from coaster.db import db
-
-from .test_sqlalchemy_models import Container, NamedDocument, ScopedNamedDocument
+from .test_sqlalchemy_models import Container, NamedDocument, ScopedNamedDocument, db
 
 # --- Test setup -----------------------------------------------------------------------
 

--- a/tests/test_views_classview.py
+++ b/tests/test_views_classview.py
@@ -13,7 +13,6 @@ from werkzeug.exceptions import Forbidden
 import pytest
 
 from coaster.auth import add_auth_attribute
-from coaster.db import SQLAlchemy
 from coaster.sqlalchemy import BaseIdNameMixin, BaseNameMixin, BaseScopedNameMixin
 from coaster.utils import InspectableSet
 from coaster.views import (
@@ -32,6 +31,8 @@ from coaster.views import (
     viewdata,
 )
 
+from .test_sqlalchemy_models import db
+
 
 class JsonEncoder(json.JSONEncoder):
     def default(self, o):
@@ -45,7 +46,7 @@ app.json_encoder = JsonEncoder
 app.testing = True
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db = SQLAlchemy(app)
+db.init_app(app)
 
 
 # --- Models ---------------------------------------------------------------------------

--- a/tests/test_views_loadmodels.py
+++ b/tests/test_views_loadmodels.py
@@ -298,6 +298,7 @@ class TestLoadModels(unittest.TestCase):
         db.drop_all()
         self.ctx.pop()
 
+    @pytest.mark.flaky()
     def test_container(self):
         with self.app.test_request_context():
             login_manager.set_user_for_testing(User(username='test'), load=True)
@@ -310,6 +311,7 @@ class TestLoadModels(unittest.TestCase):
             == self.nd2
         )
 
+    @pytest.mark.flaky()
     def test_redirect_document(self):
         with self.app.test_request_context('/c/named-document'):
             assert (
@@ -342,6 +344,7 @@ class TestLoadModels(unittest.TestCase):
             == self.snd2
         )
 
+    @pytest.mark.flaky()
     def test_id_named_document(self):
         assert (
             t_id_named_document(container='c', document='1-id-named-document')
@@ -368,6 +371,7 @@ class TestLoadModels(unittest.TestCase):
         assert t_scoped_id_document(container='c', document=1) == self.sid1
         assert t_scoped_id_document(container='c', document=2) == self.sid2
 
+    @pytest.mark.flaky()
     def test_scoped_id_named_document(self):
         assert (
             t_scoped_id_named_document(
@@ -423,6 +427,7 @@ class TestLoadModels(unittest.TestCase):
         assert self.pc.permissions(user, inherited=inherited) == {'add-video', 'view'}
         assert inherited == {'add-video'}
 
+    @pytest.mark.flaky()
     def test_loadmodel_permissions(self):
         with self.app.test_request_context():
             login_manager.set_user_for_testing(User(username='foo'), load=True)
@@ -431,6 +436,7 @@ class TestLoadModels(unittest.TestCase):
             with pytest.raises(Forbidden):
                 t_dotted_document_delete(document='parent', child=1)
 
+    @pytest.mark.flaky()
     def test_load_user_to_g(self):
         with self.app.test_request_context():
             user = User(username='baz')
@@ -441,6 +447,7 @@ class TestLoadModels(unittest.TestCase):
             with pytest.raises(NotFound):
                 t_load_user_to_g(username='boo')
 
+    @pytest.mark.flaky()
     def test_single_model_in_loadmodels(self):
         with self.app.test_request_context():
             user = User(username='user1')

--- a/tests/test_views_loadmodels.py
+++ b/tests/test_views_loadmodels.py
@@ -61,7 +61,7 @@ class ChildDocument(BaseScopedIdMixin, db.Model):
     parent_id = sa.Column(  # type: ignore[call-overload]
         sa.Integer, sa.ForeignKey('middle_container.id')
     )
-    parent: MiddleContainer = relationship(MiddleContainer, backref='children')
+    parent = relationship(MiddleContainer, backref='children')
 
     def permissions(self, actor, inherited=None):
         if inherited is None:
@@ -78,12 +78,12 @@ class RedirectDocument(BaseNameMixin, db.Model):
     container_id = sa.Column(  # type: ignore[call-overload]
         sa.Integer, sa.ForeignKey('container.id')
     )
-    container: Container = relationship(Container)
+    container = relationship(Container)
 
     target_id = sa.Column(  # type: ignore[call-overload]
         sa.Integer, sa.ForeignKey('named_document.id')
     )
-    target: NamedDocument = relationship(NamedDocument)
+    target = relationship(NamedDocument)
 
     def redirect_view_args(self):
         return {'document': self.target.name}


### PR DESCRIPTION
The `request_has_auth` helper function accompanying `current_auth` is meant to be used in an after_request processor to set a `Vary: Cookie` header if the request accessed `current_auth` in any way, implying that it is auth-sensitive. Unfortunately, since the `current_auth` proxy is included in the Jinja2 environment, this means any rendering of a template will invoke current_auth, even if the template does not need it.

This PR changes `current_auth` to only initialize itself when the `actor` or `user` properties are read, thereby removing the Jinja2 issue.

Potential problem: if a view or template does access `current_auth`, but in the very first access attempts to read another variable that was expected to be set by the login manager, it will not exist as the login manager will only be called when `user` or `actor` is accessed.

Potential fix: Implement `__getattr__` to (a) call login_manager if no actor attr has been set, or (b) always raise AttributeError post-init. This will have the bonus upside of `user` and `actor` not being properties with duplicated code.