### PR TITLE
Drop use of UUIDType from SQLAlchemy-Utils, and drop SQLite tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,12 @@
 ci:
   skip: ["yesqa", "no-commit-to-branch"]
 repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.265
+    hooks:
+      - id: ruff
+        args: ['--fix', '--exit-non-zero-on-fix']
+        # Extra args, only after removing flake8 and yesqa: '--extend-select', 'RUF100'
   - repo: https://github.com/lucasmbrown/mirrors-autoflake
     rev: v1.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,8 @@ known_flask = [
   'flask_flatpages',
   'flask_mail',
   'flask_migrate',
-  'flask_rq2'
+  'flask_rq2',
+  'flask_sqlalchemy'
 ]
 default_section = 'THIRDPARTY'
 sections = ['FUTURE', 'STDLIB', 'SQLALCHEMY', 'FLASK', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
@@ -174,3 +175,54 @@ exclude_dirs = ['node_modules', 'build/lib']
 
 [tool.bandit.assert_used]
 skips = ['*/*_test.py', '*/test_*.py']
+
+[tool.ruff]
+# This is a slight customisation of the default rules
+# 1. Coaster still supports Python 3.7 pending its EOL
+# 2. Rule E402 (module-level import not top-level) is disabled as isort handles it
+# 3. Rule E501 (line too long) is left to Black; some strings are worse for wrapping
+
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = ["E402", "E501"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Target Python 3.7
+target-version = "py37"
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10

--- a/src/coaster/db.py
+++ b/src/coaster/db.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 from sqlite3 import Connection as SQLite3Connection
 
-from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.engine import Engine
 import sqlalchemy.event as event  # pylint: disable=consider-using-from-import
+
+from flask_sqlalchemy import SQLAlchemy
 
 try:
     from psycopg2.extensions import connection as PostgresConnection  # noqa: N812

--- a/src/coaster/sqlalchemy/columns.py
+++ b/src/coaster/sqlalchemy/columns.py
@@ -10,12 +10,11 @@ import json
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.types import TEXT, TypeDecorator, UserDefinedType
 from sqlalchemy_utils.types import URLType as UrlTypeBase
-from sqlalchemy_utils.types import UUIDType
 import sqlalchemy as sa
 
 from furl import furl
 
-__all__ = ['JsonDict', 'UUIDType', 'UrlType']
+__all__ = ['JsonDict', 'UrlType']
 
 
 class JsonType(UserDefinedType):

--- a/src/coaster/sqlalchemy/comparators.py
+++ b/src/coaster/sqlalchemy/comparators.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 import typing as t
 import uuid as uuid_
 
-from flask_sqlalchemy.query import Query as BaseQuery
 from sqlalchemy.ext.hybrid import Comparator
 
 from flask import abort
+from flask_sqlalchemy.query import Query as BaseQuery
 
 from ..utils import uuid_from_base58, uuid_from_base64
 

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -28,10 +28,10 @@ from decimal import Decimal
 from uuid import UUID, uuid4
 import typing as t
 
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declarative_mixin, declared_attr, synonym
 from sqlalchemy.sql import func, select
-from sqlalchemy_utils.types import UUIDType
 import sqlalchemy as sa
 
 from flask import Flask, current_app, url_for
@@ -106,10 +106,7 @@ class IdMixin:
         if cls.__uuid_primary_key__:
             return immutable(
                 sa.Column(
-                    UUIDType(binary=False),
-                    default=uuid4,
-                    primary_key=True,
-                    nullable=False,
+                    postgresql.UUID, default=uuid4, primary_key=True, nullable=False
                 )
             )
         return immutable(sa.Column(sa.Integer, primary_key=True, nullable=False))
@@ -175,12 +172,7 @@ class UuidMixin:
         if hasattr(cls, '__uuid_primary_key__') and cls.__uuid_primary_key__:
             return synonym('id')
         return immutable(
-            sa.Column(
-                UUIDType(binary=False),
-                default=uuid4,
-                unique=True,
-                nullable=False,
-            )
+            sa.Column(postgresql.UUID, default=uuid4, unique=True, nullable=False)
         )
 
     @hybrid_property

--- a/src/coaster/utils/misc.py
+++ b/src/coaster/utils/misc.py
@@ -628,7 +628,7 @@ def valid_username(candidate):
     ...   valid_username('-ab'))
     False
     """
-    return not _username_valid_re.search(candidate) is None
+    return _username_valid_re.search(candidate) is not None
 
 
 def namespace_from_url(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Reusable fixtures for Coaster tests."""
+
+from os import environ
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+import pytest
+
+db = SQLAlchemy()
+
+
+# This is NOT a fixture
+def sqlalchemy_uri() -> str:
+    """Return SQLAlchemy database URI (deferring to value in environment)."""
+    return environ.get(
+        'FLASK_SQLALCHEMY_DATABASE_URI', 'postgresql://localhost/coaster_test'
+    )
+
+
+@pytest.fixture(scope='module')
+def app() -> Flask:
+    """App fixture."""
+    _app = Flask(__name__)
+    _app.config['SQLALCHEMY_DATABASE_URI'] = sqlalchemy_uri()
+    _app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(_app)
+    return _app
+
+
+@pytest.fixture(scope='class')
+def clsapp(request, app: Flask) -> Flask:
+    """App fixture in unittest class."""
+    request.cls.app = app
+    return app

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,10 +5,9 @@ from types import SimpleNamespace
 import typing as t  # noqa: F401  # pylint: disable=unused-import
 import uuid as uuid_  # noqa: F401  # pylint: disable=unused-import
 
-from flask_sqlalchemy import SQLAlchemy
 import sqlalchemy as sa  # noqa: F401  # pylint: disable=unused-import
 
-from flask import Flask, g, has_request_context, render_template_string
+from flask import g, has_request_context, render_template_string
 
 import pytest
 
@@ -28,6 +27,8 @@ from coaster.sqlalchemy import (  # noqa: F401  # pylint: disable=unused-import
     TimestampMixin,
     UrlForMixin,
 )
+
+from .conftest import db
 
 # --- App context ----------------------------------------------------------------------
 
@@ -65,7 +66,7 @@ class FlaskLoginManager(LoginManager):  # pylint: disable=too-few-public-methods
 
 
 @pytest.fixture(scope='module')
-def models(db) -> SimpleNamespace:
+def models() -> SimpleNamespace:
     """Model fixtures."""
     # pylint: disable=possibly-unused-variable
 
@@ -101,22 +102,6 @@ def models(db) -> SimpleNamespace:
 # --- Fixtures -------------------------------------------------------------------------
 
 
-@pytest.fixture(scope='module')
-def app() -> Flask:
-    """App fixture."""
-    _app = Flask(__name__)
-    _app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-    _app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    return _app
-
-
-@pytest.fixture(scope='module')
-def db(app) -> SQLAlchemy:
-    """Database fixture."""
-    _db = SQLAlchemy(app)
-    return _db
-
-
 @pytest.fixture()
 def login_manager(app):
     """Login manager fixture."""
@@ -132,7 +117,7 @@ def flask_login_manager(app):
 
 
 @pytest.fixture()
-def request_ctx(app, db):
+def request_ctx(app):
     """Request context with database models."""
     ctx = app.test_request_context()
     ctx.push()

--- a/tests/test_sqlalchemy_annotations.py
+++ b/tests/test_sqlalchemy_annotations.py
@@ -6,8 +6,6 @@ from sqlalchemy.orm.attributes import NO_VALUE
 import sqlalchemy as sa
 import sqlalchemy.exc
 
-from flask import Flask
-
 import pytest
 
 from coaster.sqlalchemy import (
@@ -18,13 +16,7 @@ from coaster.sqlalchemy import (
     immutable,
 )
 
-from .test_sqlalchemy_models import db
-
-app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db.init_app(app)
-
+from .conftest import db
 
 # --- Models ---------------------------------------------------------------------------
 
@@ -120,9 +112,8 @@ class SynonymAnnotation(BaseMixin, db.Model):  # type: ignore[name-defined]
 # --- Tests ----------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures('clsapp')
 class TestCoasterAnnotations(unittest.TestCase):
-    app = app
-
     def setUp(self):
         self.ctx = self.app.test_request_context()
         self.ctx.push()

--- a/tests/test_sqlalchemy_coordinates.py
+++ b/tests/test_sqlalchemy_coordinates.py
@@ -3,21 +3,27 @@
 from uuid import UUID  # noqa: F401  # pylint: disable=unused-import
 import unittest
 
+import pytest
+
 from coaster.sqlalchemy import BaseMixin, CoordinatesMixin
 
-from .test_sqlalchemy_models import app2, db
+from .conftest import db
 
 
-class CoordinatesData(BaseMixin, CoordinatesMixin, db.Model):  # type: ignore[name-defined]
+class CoordinatesData(
+    BaseMixin, CoordinatesMixin, db.Model  # type: ignore[name-defined]
+):
+    """Test model for coordinates data."""
+
     __tablename__ = 'coordinates_data'
 
 
 # -- Tests --------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures('clsapp')
 class TestCoordinatesColumn(unittest.TestCase):
-    # Restrict tests to PostgreSQL as SQLite3 doesn't have a Decimal type
-    app = app2
+    """Test for coordinates column."""
 
     def setUp(self):
         self.ctx = self.app.test_request_context()
@@ -63,4 +69,5 @@ class TestCoordinatesColumn(unittest.TestCase):
         db.session.commit()
 
         readdata = CoordinatesData.query.first()
+        assert readdata.coordinates == (12, 73)
         assert readdata.coordinates == (12, 73)

--- a/tests/test_sqlalchemy_markdowncolumn.py
+++ b/tests/test_sqlalchemy_markdowncolumn.py
@@ -3,10 +3,12 @@
 from uuid import UUID  # noqa: F401  # pylint: disable=unused-import
 import unittest
 
+import pytest
+
 from coaster.gfm import markdown
 from coaster.sqlalchemy import BaseMixin, MarkdownColumn
 
-from .test_sqlalchemy_models import app1, app2, db
+from .conftest import db
 
 
 class MarkdownData(BaseMixin, db.Model):  # type: ignore[name-defined]
@@ -31,9 +33,8 @@ class FakeMarkdownData(BaseMixin, db.Model):  # type: ignore[name-defined]
 # -- Tests --------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures('clsapp')
 class TestMarkdownColumn(unittest.TestCase):
-    app = app1
-
     def setUp(self):
         self.ctx = self.app.test_request_context()
         self.ctx.push()
@@ -136,7 +137,3 @@ class TestMarkdownColumn(unittest.TestCase):
         doc = FakeMarkdownData(value="This is some text")
         assert doc.value.text == "This is some text"
         assert doc.value.html == 'fake-markdown'
-
-
-class TestMarkdownColumn2(TestMarkdownColumn):
-    app = app2

--- a/tests/test_sqlalchemy_registry.py
+++ b/tests/test_sqlalchemy_registry.py
@@ -8,7 +8,7 @@ import pytest
 from coaster.sqlalchemy import BaseMixin
 from coaster.sqlalchemy.registry import Registry
 
-from .test_sqlalchemy_models import db
+from .conftest import db
 
 # --- Fixtures -------------------------------------------------------------------------
 

--- a/tests/test_sqlalchemy_roles.py
+++ b/tests/test_sqlalchemy_roles.py
@@ -18,8 +18,6 @@ except ModuleNotFoundError:  # type: ignore[unreachable]
         column_mapped_collection as column_keyed_dict,
     )
 
-from flask import Flask
-
 import pytest
 
 from coaster.sqlalchemy import (
@@ -35,13 +33,7 @@ from coaster.sqlalchemy import (
 )
 from coaster.utils import InspectableSet
 
-from .test_sqlalchemy_models import db
-
-app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db.init_app(app)
-
+from .conftest import db
 
 # --- Models ---------------------------------------------------------------------------
 
@@ -410,9 +402,8 @@ class JsonProtocolEncoder(json.JSONEncoder):
 # --- Tests ----------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures('clsapp')
 class TestCoasterRoles(unittest.TestCase):
-    app = app
-
     def setUp(self):
         self.ctx = self.app.test_request_context()
         self.ctx.push()

--- a/tests/test_statemanager.py
+++ b/tests/test_statemanager.py
@@ -2,10 +2,7 @@ from datetime import datetime, timedelta
 from uuid import UUID  # noqa: F401  # pylint: disable=unused-import
 import unittest
 
-from flask_sqlalchemy import SQLAlchemy
 import sqlalchemy as sa  # pylint: disable=unused-import  # noqa: F401
-
-from flask import Flask
 
 import pytest
 
@@ -20,11 +17,7 @@ from coaster.sqlalchemy import (
 from coaster.sqlalchemy.statemanager import ManagedStateWrapper
 from coaster.utils import LabeledEnum
 
-app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db = SQLAlchemy(app)
-
+from .conftest import db
 
 # --- Models ---------------------------------------------------------------------------
 
@@ -163,11 +156,8 @@ class MyPost(BaseMixin, db.Model):  # type: ignore[name-defined]
 # --- Tests ----------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures('clsapp')
 class TestStateManager(unittest.TestCase):
-    """SQLite tests"""
-
-    app = app
-
     def setUp(self):
         self.ctx = self.app.test_request_context()
         self.ctx.push()

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -5,17 +5,18 @@ from werkzeug.routing import BuildError
 
 import pytest
 
+from .conftest import sqlalchemy_uri
 from .test_sqlalchemy_models import Container, NamedDocument, ScopedNamedDocument, db
 
 # --- Test setup -----------------------------------------------------------------------
 
 app1 = Flask(__name__)
-app1.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+app1.config['SQLALCHEMY_DATABASE_URI'] = sqlalchemy_uri()
 app1.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app1)
 
 app2 = Flask(__name__)
-app2.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+app2.config['SQLALCHEMY_DATABASE_URI'] = sqlalchemy_uri()
 app2.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app2)
 

--- a/tests/test_views_classview.py
+++ b/tests/test_views_classview.py
@@ -28,7 +28,7 @@ from coaster.views import (
     viewdata,
 )
 
-from .test_sqlalchemy_models import db
+from .conftest import db, sqlalchemy_uri
 
 
 class JsonEncoder(json.JSONEncoder):
@@ -41,7 +41,7 @@ class JsonEncoder(json.JSONEncoder):
 app = Flask(__name__)
 app.json_encoder = JsonEncoder
 app.testing = True
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+app.config['SQLALCHEMY_DATABASE_URI'] = sqlalchemy_uri()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 

--- a/tests/test_views_loadmodels.py
+++ b/tests/test_views_loadmodels.py
@@ -6,7 +6,7 @@ import unittest
 from sqlalchemy.orm import Mapped, relationship
 import sqlalchemy as sa
 
-from flask import Flask, g
+from flask import g
 from werkzeug.exceptions import Forbidden, NotFound
 
 import pytest
@@ -23,8 +23,6 @@ from .test_sqlalchemy_models import (
     ScopedIdNamedDocument,
     ScopedNamedDocument,
     User,
-    app1,
-    app2,
     db,
 )
 
@@ -217,16 +215,16 @@ def t_dotted_document_delete(document, child):
 # --- Tests ----------------------------------------------------------------------------
 
 
-class TestLoadModels(unittest.TestCase):
-    app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = app1.config['SQLALCHEMY_DATABASE_URI']
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    db.init_app(app)
+@pytest.fixture(scope='module', autouse=True)
+def _app_extra(app):
     LoginManager(app)
     app.add_url_rule(
         '/<container>/<document>', 'redirect_document', t_redirect_document
     )
 
+
+@pytest.mark.usefixtures('clsapp')
+class TestLoadModels(unittest.TestCase):
     def setUp(self):
         self.ctx = self.app.test_request_context()
         self.ctx.push()
@@ -451,14 +449,3 @@ class TestLoadModels(unittest.TestCase):
             self.session.add(user)
             self.session.commit()
             assert t_single_model_in_loadmodels(username='user1') == g.user
-
-
-class TestLoadModels2(TestLoadModels):
-    app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = app2.config['SQLALCHEMY_DATABASE_URI']
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    db.init_app(app)
-    LoginManager(app)
-    app.add_url_rule(
-        '/<container>/<document>', 'redirect_document', t_redirect_document
-    )


### PR DESCRIPTION
UUIDType has been a recurring source of pain as SQLAlchemy doesn't understand the type (and queries are broken in SQLAlchemy 2.0.x), so we're dropping it to commit to SQLAlchemy's own PostgreSQL-only UUID column. This means the SQLite tests are no longer usable and have to be removed.