### PR TITLE
WebpackManifest Flask extension for Webpack assets in Jinja2 templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@
 * ``render_with`` no longer offers a shorthand for JSONP responses
 * ``coaster.sqlalchemy.ModelBase`` now replaces Flask-SQLAlchemy's db.Model
   with full support for type hinting
+* New: ``coaster.assets.WebpackManifest`` provides Webpack assets in Jinja2
 
 0.6.1 - 2021-01-06
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,5 +242,5 @@ split-on-trailing-comma = false
 relative-imports-order = 'furthest-to-closest'
 known-first-party = ['coaster']
 section-order = [
-  'future', 'standard-library', 'third-party', 'first-party', 'repo', 'local-folder'
+  'future', 'standard-library', 'third-party', 'first-party', 'local-folder'
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ classmethod-decorators=classmethod, declared_attr, expression, comparator
 [pycodestyle]
 max-line-length = 88
 max-doc-length = 88
-add-ignore = E203
+ignore = D101, D102, D103, D105, D107, D402, E203, W503
 
 [pydocstyle]
 convention = pep257

--- a/src/coaster/assets.py
+++ b/src/coaster/assets.py
@@ -32,7 +32,13 @@ from semantic_version import SimpleSpec, Version
 _VERSION_SPECIFIER_RE = re.compile('[<=>!*]')
 
 # Version is not used here but is made available for others to import from
-__all__ = ['Version', 'SimpleSpec', 'VersionedAssets', 'AssetNotFound']
+__all__ = [
+    'Version',
+    'SimpleSpec',
+    'VersionedAssets',
+    'AssetNotFound',
+    'WebpackManifest',
+]
 
 
 def split_namespec(namespec: str) -> t.Tuple[str, SimpleSpec]:

--- a/src/coaster/assets.py
+++ b/src/coaster/assets.py
@@ -197,7 +197,7 @@ class WebpackManifest(Mapping):
     """
     Webpack asset manifest extension for Flask and Jinja2.
 
-    WebpackManifest loads a ``manifest.json`` file produced by Webpack_, and makes the
+    WebpackManifest loads a ``manifest.json`` file produced by Webpack_ and makes the
     contents available to Jinja2 templates as ``{{ manifest['asset_name.ext'] }}``. Call
     syntax is also supported and accepts an optional default for missing assets,
     defaulting to a browser-friendly empty value ``data:,``. The standard dictionary
@@ -230,9 +230,7 @@ class WebpackManifest(Mapping):
 
     WebpackManifest does not hold the asset data. It loads and stores it as
     ``app.config['manifest.json']`` during the :meth:`init_app` call, and therefore
-    requires an app context to retrieve the path. If an unknown asset is requested, it
-    will return the static string ``data:,`` instead of raising an exception. Browsers
-    should parse this as a valid URI with an empty body.
+    requires an app context at runtime.
 
     :param app: Flask app, can be supplied later by calling :meth:`init_app`
     :param filepath: Path to the manifest JSON file relative to the app folder

--- a/tests/coaster_tests/assets_test.py
+++ b/tests/coaster_tests/assets_test.py
@@ -1,75 +1,520 @@
-import unittest
+"""Tests for asset management helpers."""
+# pylint: disable=redefined-outer-name
+
+import json
+import re
+import typing as t
+from io import StringIO
+from unittest.mock import patch
 
 import pytest
+from flask import Flask, render_template_string
 
-from coaster.assets import AssetNotFound, Version, VersionedAssets
+from coaster.assets import AssetNotFound, Version, VersionedAssets, WebpackManifest
+
+# --- VersionedAssets tests ------------------------------------------------------------
 
 
-class TestAssets(unittest.TestCase):
-    def setUp(self) -> None:
-        self.assets = VersionedAssets()
-        self.assets['jquery.js'][Version('1.7.1')] = 'jquery-1.7.1.js'
-        self.assets['jquery.js'][Version('1.8.3')] = 'jquery-1.8.3.js'
-        self.assets['jquery.some.js'][Version('1.8.3')] = {
-            'provides': 'jquery.js',
-            'requires': 'jquery.js',
-            'bundle': None,
-        }
-        self.assets['jquery.form.js'][Version('2.96.0')] = (
-            'jquery.js',
-            'jquery.form-2.96.js',
+@pytest.fixture()
+def assets() -> VersionedAssets:
+    """Sample asset fixture."""
+    _assets = VersionedAssets()
+    _assets['jquery.js'][Version('1.7.1')] = 'jquery-1.7.1.js'
+    _assets['jquery.js'][Version('1.8.3')] = 'jquery-1.8.3.js'
+    _assets['jquery.some.js'][Version('1.8.3')] = {
+        'provides': 'jquery.js',
+        'requires': 'jquery.js',
+        'bundle': None,
+    }
+    _assets['jquery.form.js'][Version('2.96.0')] = (
+        'jquery.js',
+        'jquery.form-2.96.js',
+    )
+    _assets['jquery.form.1.js'][Version('2.96.0')] = {
+        'requires': 'jquery.js>=1.8.3',
+        'provides': 'jquery.form.js',
+    }
+    _assets['old-lib.js'][Version('1.0.0')] = (
+        'jquery.js<1.8.0',
+        'old-lib-1.0.0.js',
+    )
+    return _assets
+
+
+def test_asset_unversioned(assets: VersionedAssets) -> None:
+    """Assets can be loaded without a version specifier to get the latest."""
+    bundle = assets.require('jquery.js')
+    assert bundle.contents == ('jquery-1.8.3.js',)
+
+
+def test_asset_versioned(assets: VersionedAssets) -> None:
+    """Specific versions can be requested."""
+    bundle = assets.require('jquery.js==1.7.1')
+    assert bundle.contents == ('jquery-1.7.1.js',)
+    bundle = assets.require('jquery.js<1.8.0')
+    assert bundle.contents == ('jquery-1.7.1.js',)
+    bundle = assets.require('jquery.js>=1.8.0')
+    assert bundle.contents == ('jquery-1.8.3.js',)
+
+
+def test_missing_asset(assets: VersionedAssets) -> None:
+    """A missing asset raises an exception."""
+    with pytest.raises(AssetNotFound):
+        assets.require('missing.js')
+
+
+def test_single_requires(assets: VersionedAssets) -> None:
+    """An asset can be specified as a tuple containing all requirements."""
+    # See fixture for how the asset is described
+    bundle = assets.require('jquery.form.js')
+    assert bundle.contents == ('jquery-1.8.3.js', 'jquery.form-2.96.js')
+
+
+def test_single_requires_which_is_dict(assets: VersionedAssets) -> None:
+    """An asset can be specified as a dictionary."""
+    # See fixture for how the asset is described
+    bundle = assets.require('jquery.form.1.js')
+    assert bundle.contents == ('jquery-1.8.3.js',)
+
+
+def test_provides_requires(assets: VersionedAssets) -> None:
+    """An asset can claim provide another asset."""
+    # See fixture for how the asset is described
+    bundle = assets.require('jquery.some.js', 'jquery.form.js')
+    assert bundle.contents == ('jquery-1.8.3.js', 'jquery.form-2.96.js')
+
+
+def test_version_copies(assets: VersionedAssets) -> None:
+    """Asset versions are NOT resolved automatically, requiring some care."""
+    # First asset will load highest available version of the requirement, which
+    # conflicts with the second requested version. The same asset can't be requested
+    # twice
+    with pytest.raises(
+        ValueError,
+        match='jquery.js==.*? does not match already requested asset jquery.js==.*?',
+    ):
+        assets.require('jquery.form.js', 'jquery.js==1.7.1')
+
+
+def test_version_conflict(assets: VersionedAssets) -> None:
+    """Asset version conflicts will cause an error."""
+    # First asset will load highest available version of the requirement, which
+    # conflicts with the second requested version. The same asset can't be requested
+    # twice
+    with pytest.raises(
+        ValueError,
+        match='jquery.js<.*? is not compatible with already requested version 1.8.3',
+    ):
+        assets.require('jquery.form.js', 'old-lib.js')
+
+
+def test_blacklist(assets: VersionedAssets) -> None:
+    """An asset can be removed from the bundle using a ``!`` prefix."""
+    bundle = assets.require('!jquery.js', 'jquery.form.js')
+    assert bundle.contents == ('jquery.form-2.96.js',)
+    bundle = assets.require('jquery.form.js', '!jquery.js')
+    assert bundle.contents == ('jquery.form-2.96.js',)
+
+
+# --- WebpackManifest tests ------------------------------------------------------------
+
+
+# --- Fixtures
+# The `app` fixture from conftest has module scope, so we have function-scoped fixtures
+# for the tests here
+
+
+@pytest.fixture()
+def app1() -> Flask:
+    """First Flask app fixture."""
+    return Flask(__name__)
+
+
+@pytest.fixture()
+def app2() -> Flask:
+    """Second Flask app fixture."""
+    return Flask(__name__)
+
+
+# --- Tests: basic operations, object can be created, methods can be called
+
+
+def test_create_empty_manifest() -> None:
+    """An empty manifest can exist and works without an app."""
+    manifest = WebpackManifest()
+    assert len(manifest) == 0
+    assert not list(iter(manifest))
+    assert 'random' not in manifest
+    assert manifest['random'] == 'data:,'
+    assert manifest('random') == 'data:,'
+    assert manifest.get('random') is None
+    assert manifest.get('random', 'default-value') == 'default-value'
+
+
+def test_unaffiliated_manifest(app1: Flask) -> None:
+    """A manifest not affiliated with an app will work in the app's context."""
+    manifest = WebpackManifest()
+    with app1.app_context():
+        assert len(manifest) == 0
+        assert not list(iter(manifest))
+        assert 'random' not in manifest
+        assert manifest['random'] == 'data:,'
+        assert manifest('random') == 'data:,'
+        assert manifest.get('random') is None
+        assert manifest.get('random', 'default-value') == 'default-value'
+
+
+@pytest.mark.parametrize(
+    ('search_paths', 'error'),
+    [
+        (
+            None,
+            re.escape(
+                "No asset manifest found in locations"
+                " ['static/manifest.json', 'static/build/manifest.json']"
+            ),
+        ),
+        (
+            ['does-not-exist.json'],
+            re.escape("No asset manifest found in locations ['does-not-exist.json']"),
+        ),
+    ],
+)
+def test_manifest_search_paths(
+    app1: Flask, search_paths: t.Optional[str], error: str
+) -> None:
+    """The search paths can be customized and will be replayed in FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match=error):
+        WebpackManifest(app1, search_paths=search_paths)
+
+
+def test_load_manifest_from_file_as_secondary_search_path(app1: Flask) -> None:
+    """Given multiple search paths, the file can be found anywhere in the list."""
+    manifest = WebpackManifest(
+        app1, search_paths=['does-not-exist.json', 'test-manifest.json']
+    )
+    with app1.app_context():
+        assert len(manifest) == 6
+
+
+def test_load_manifest_from_file(app1: Flask) -> None:
+    """A test manifest file is loaded correctly, with substitutions."""
+    manifest = WebpackManifest(app1, search_paths=['test-manifest.json'])
+    assert len(manifest) == 0
+    with app1.app_context():
+        assert len(manifest) == 6
+        assert 'test.css' in manifest
+        assert 'other.css' not in manifest
+        assert 'index.scss' in manifest
+        assert 'index.css' in manifest
+        assert (
+            manifest['test.css']
+            == manifest('test.css')
+            == manifest.get('test.css')
+            == 'test-file-does-not-really-exist.css'
         )
-        self.assets['jquery.form.1.js'][Version('2.96.0')] = {
-            'requires': 'jquery.js>=1.8.3',
-            'provides': 'jquery.form.js',
+        assert (
+            manifest['index.scss']
+            == manifest('index.scss')
+            == manifest.get('index.scss')
+            == manifest['index.css']
+            == manifest('index.css')
+            == manifest.get('index.css')
+            == 'this-is-index.css'
+        )
+        # Call iter(manifest) to confirm it works, then recast as set for comparison
+        assert set(iter(manifest)) == {
+            'index.css',  # index.css was created as a substitute name for index.scss
+            'index.scss',
+            'test.css',
+            'test.jpg',
+            'test.js',
+            'test.png',
         }
-        self.assets['old-lib.js'][Version('1.0.0')] = (
-            'jquery.js<1.8.0',
-            'old-lib-1.0.0.js',
+        # Since other.css is not present, a default value is returned
+        assert manifest['other.css'] == manifest('other.css') == 'data:,'
+        assert manifest.get('other.css') is None
+        assert manifest.get('other.css', 'default-value') == 'default-value'
+
+
+def test_manifest_limited_to_app_with_context(app1: Flask, app2: Flask) -> None:
+    """A manifest loaded for one app is not available in another app's context."""
+    manifest = WebpackManifest(
+        app1, search_paths=['test-manifest.json'], base_path='/test-prefix'
+    )
+    assert len(manifest) == 0
+    with app1.app_context():
+        assert len(manifest) == 6
+        assert (
+            manifest['test.css']
+            == manifest('test.css')
+            == manifest.get('test.css')
+            == '/test-prefix/test-file-does-not-really-exist.css'
+        )
+    with app2.app_context():
+        assert len(manifest) == 0
+        # But we can fake the content and the extension works
+        app2.config['manifest.json'] = {'test-entry': 'test-value'}
+        assert len(manifest) == 1
+        assert manifest['test-entry'] == '/test-prefix/test-value'
+
+
+# --- Tests for options: custom base path, substitute asset names
+
+
+def test_load_manifest_from_file_with_custom_base_path(app1: Flask) -> None:
+    """A base path is added to the values in the manifest."""
+    manifest = WebpackManifest(
+        app1, search_paths=['test-manifest.json'], base_path='/static'
+    )
+    assert len(manifest) == 0
+    with app1.app_context():
+        assert len(manifest) == 6
+        assert 'test.css' in manifest
+        assert 'other.css' not in manifest
+        assert 'index.scss' in manifest
+        assert 'index.css' in manifest
+        assert (
+            manifest['test.css']
+            == manifest('test.css')
+            == manifest.get('test.css')
+            == '/static/test-file-does-not-really-exist.css'
+        )
+        assert (
+            manifest['index.scss']
+            == manifest('index.scss')
+            == manifest.get('index.scss')
+            == manifest['index.css']
+            == manifest('index.css')
+            == manifest.get('index.css')
+            == '/static/this-is-index.css'
+        )
+        # Since other.css is not present, the base path is not prefixed to default value
+        assert manifest['other.css'] == manifest('other.css') == 'data:,'
+        assert manifest.get('other.css') is None
+        assert manifest.get('other.css', 'default-value') == 'default-value'
+
+
+def test_manifest_disable_substitutions(app1: Flask, app2: Flask) -> None:
+    """Asset name substitutions can be disabled by passing an empty list."""
+    manifest1 = WebpackManifest(app1, search_paths=['test-manifest.json'])
+    manifest2 = WebpackManifest(
+        app2, search_paths=['test-manifest.json'], substitutes=[], base_path='/nosub'
+    )
+    # Manifest instances can be used interchangeably with app instances
+    # Manifest1 is linked to App1 with default substitutions and no base path
+    # Manifest2 is linked to App2 with no substitutions and a base path
+    with app1.app_context():
+        assert len(manifest1) == 6
+        assert len(manifest2) == 6
+        assert manifest1['test.css'] == 'test-file-does-not-really-exist.css'
+        assert manifest2['test.css'] == '/nosub/test-file-does-not-really-exist.css'
+        assert 'index.css' in manifest1
+        assert 'index.css' in manifest2
+        assert manifest1['index.scss'] == manifest1['index.css'] == 'this-is-index.css'
+        assert (
+            manifest2['index.scss']
+            == manifest2['index.css']
+            == '/nosub/this-is-index.css'
+        )
+    # App2 will not have the substitutes
+    with app2.app_context():
+        assert len(manifest1) == 5
+        assert len(manifest2) == 5
+        assert manifest1['test.css'] == 'test-file-does-not-really-exist.css'
+        assert manifest2['test.css'] == '/nosub/test-file-does-not-really-exist.css'
+        assert 'index.css' not in manifest1
+        assert 'index.css' not in manifest2
+        assert manifest1['index.scss'] == 'this-is-index.css'
+        assert manifest1['index.css'] == 'data:,'
+        assert manifest2['index.scss'] == '/nosub/this-is-index.css'
+        assert manifest2['index.css'] == 'data:,'
+
+
+def test_compiled_regex_substitutes(app1: Flask) -> None:
+    """Substitutions can be specified as compiled regex patterns."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(json.dumps({'test.jpg': 'img/test.jpg'}))
+        manifest = WebpackManifest(app1, substitutes=[(re.compile(r'\.jpg$'), '.jpeg')])
+        with app1.app_context():
+            assert set(manifest) == {'test.jpg', 'test.jpeg'}
+            assert manifest['test.jpg'] == manifest['test.jpeg'] == 'img/test.jpg'
+
+
+def test_multiple_substitutes(app1: Flask) -> None:
+    """One asset can have multiple substitute names."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(
+            json.dumps({'test.jpg': 'img/test.jpg', 'test.png': 'img/test.png'})
+        )
+        manifest = WebpackManifest(
+            app1,
+            substitutes=[
+                (re.compile(r'\.jpg$'), '.jpeg'),
+                (r'\.jpg$', '.jpeg-image'),
+                (r'\.png$', '.png-image'),
+            ],
+        )
+        with app1.app_context():
+            assert set(manifest) == {
+                'test.jpg',
+                'test.jpeg',
+                'test.jpeg-image',
+                'test.png',
+                'test.png-image',
+            }
+            assert (
+                manifest['test.jpg']
+                == manifest['test.jpeg']
+                == manifest['test.jpeg-image']
+                == 'img/test.jpg'
+            )
+
+
+def test_substitute_overlap_warning(app1: Flask) -> None:
+    """If a substitute name is already present, a warning is raised."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(
+            json.dumps({'test.jpg': 'img/test.jpg', 'test.png': 'img/test.png'})
+        )
+        with pytest.warns(RuntimeWarning):
+            manifest = WebpackManifest(
+                app1,
+                substitutes=[
+                    (r'\.jpg$', '.image'),
+                    (r'\.png$', '.image'),
+                ],
+            )
+        with app1.app_context():
+            assert set(manifest) == {'test.jpg', 'test.png', 'test.image'}
+            assert manifest['test.jpg'] == manifest['test.image'] == 'img/test.jpg'
+            assert manifest['test.png'] == 'img/test.png'
+
+
+# --- Tests for misuse: dupe init, invalid manifest content, legacy manifest detection
+
+
+def test_dupe_init_app(app1: Flask) -> None:
+    """Calling init_app twice will raise a warning but will work."""
+    manifest1 = WebpackManifest(
+        app1, search_paths=['test-manifest.json'], substitutes=[]
+    )
+    with app1.app_context():
+        assert len(manifest1) == 5
+        assert manifest1['index.css'] == 'data:,'
+
+    with pytest.warns(RuntimeWarning):
+        manifest1.init_app(app1)
+    with app1.app_context():
+        assert len(manifest1) == 5
+
+    manifest2 = WebpackManifest(search_paths=['test-manifest.json'], base_path='/2')
+    with pytest.warns(RuntimeWarning):
+        manifest2.init_app(app1)
+
+    with app1.app_context():
+        assert len(manifest1) == 6  # Length increased because manifest2 added a subst.
+        assert len(manifest2) == 6
+        assert manifest1['index.css'] == 'this-is-index.css'
+        assert manifest2['index.css'] == '/2/this-is-index.css'
+
+
+def test_manifest_must_be_valid_json(app1: Flask) -> None:
+    """The manifest file must be valid JSON."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO('This is not JSON')
+        with pytest.raises(json.JSONDecodeError):
+            WebpackManifest(app1)
+
+
+def test_manifest_json_must_be_dict(app1: Flask) -> None:
+    """The manifest file must contain a JSON object."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(json.dumps(["This", "is", "a", "list"]))
+        with pytest.raises(
+            ValueError, match='must contain a JSON object at root level'
+        ):
+            WebpackManifest(app1)
+
+
+def test_legacy_webpack(app1: Flask) -> None:
+    """Legacy webpack manifest detection is on by default."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(
+            json.dumps({'assets': {'app': 'js/app.version.js'}})
+        )
+        manifest1 = WebpackManifest(app1)
+        with app1.app_context():
+            assert len(manifest1) == 1
+            assert set(manifest1) == {'app'}
+            assert manifest1['app'] == 'js/app.version.js'
+
+
+def test_legacy_no_false_alarm(app1: Flask) -> None:
+    """Legacy detection will not be confused by an asset named ``assets``."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(
+            json.dumps({'assets': 'why-is-this-called-assets.css'})
+        )
+        manifest1 = WebpackManifest(app1, base_path='/test')
+        with app1.app_context():
+            assert len(manifest1) == 1
+            assert set(manifest1) == {'assets'}
+            assert manifest1['assets'] == '/test/why-is-this-called-assets.css'
+
+
+def test_legacy_detection_disabled_on_legacy_file(app1: Flask) -> None:
+    """Legacy detection must not be disabled when processing a legacy manifest."""
+    with patch('flask.app.Flask.open_resource') as mock:
+        mock.return_value = StringIO(
+            json.dumps({'assets': {'app': 'js/app.version.js'}})
+        )
+        # If legacy detection is disabled, WebpackManifest will complain that the value
+        # is not a string
+        with pytest.raises(
+            ValueError, match="Expected string value for `static/manifest.json:assets`"
+        ):
+            WebpackManifest(app1, detect_legacy_webpack=False)
+
+
+# --- Tests for use in Jinja2 templates
+
+
+def test_jinja2_filter(app1: Flask) -> None:
+    """A Jinja2 filter is installed and can be used."""
+    manifest = WebpackManifest(app1, search_paths=['test-manifest.json'])
+    with app1.app_context():
+        assert 'test.css' in manifest
+        assert (
+            render_template_string(
+                '''<link rel="stylesheet" src="{{ manifest['test.css'] }}" />'''
+            )
+            == render_template_string(
+                '''<link rel="stylesheet" src="{{ manifest('test.css') }}" />'''
+            )
+            == render_template_string(
+                '''<link rel="stylesheet" src="{{ manifest.get('test.css') }}" />'''
+            )
+            == render_template_string(
+                '''<link rel="stylesheet" src="{{ 'test.css'|manifest }}" />'''
+            )
+            == '<link rel="stylesheet" src="test-file-does-not-really-exist.css" />'
         )
 
-    def test_asset_unversioned(self) -> None:
-        bundle = self.assets.require('jquery.js')
-        assert bundle.contents == ('jquery-1.8.3.js',)
-
-    def test_asset_versioned(self) -> None:
-        bundle = self.assets.require('jquery.js==1.7.1')
-        assert bundle.contents == ('jquery-1.7.1.js',)
-        bundle = self.assets.require('jquery.js<1.8.0')
-        assert bundle.contents == ('jquery-1.7.1.js',)
-        bundle = self.assets.require('jquery.js>=1.8.0')
-        assert bundle.contents == ('jquery-1.8.3.js',)
-
-    def test_missing_asset(self) -> None:
-        with pytest.raises(AssetNotFound):
-            self.assets.require('missing.js')
-
-    def test_single_requires(self) -> None:
-        bundle = self.assets.require('jquery.form.js')
-        assert bundle.contents == ('jquery-1.8.3.js', 'jquery.form-2.96.js')
-
-    def test_single_requires_which_is_dict(self) -> None:
-        bundle = self.assets.require('jquery.form.1.js')
-        assert bundle.contents == ('jquery-1.8.3.js',)
-
-    def test_provides_requires(self) -> None:
-        bundle = self.assets.require('jquery.some.js', 'jquery.form.js')
-        assert bundle.contents == ('jquery-1.8.3.js', 'jquery.form-2.96.js')
-
-    def test_version_copies(self) -> None:
-        # First asset will load highest available version of the requirement, which conflicts
-        # with the second requested version. The same asset can't be requested twice
-        with pytest.raises(ValueError):
-            self.assets.require('jquery.form.js', 'jquery.js==1.7.1')
-
-    def test_version_conflict(self) -> None:
-        # First asset will load highest available version of the requirement, which conflicts
-        # with the second requested version. The same asset can't be requested twice
-        with pytest.raises(ValueError):
-            self.assets.require('jquery.form.js', 'old-lib.js')
-
-    def test_blacklist(self) -> None:
-        bundle = self.assets.require('!jquery.js', 'jquery.form.js')
-        assert bundle.contents == ('jquery.form-2.96.js',)
-        bundle = self.assets.require('jquery.form.js', '!jquery.js')
-        assert bundle.contents == ('jquery.form-2.96.js',)
+        assert 'unknown.css' not in manifest
+        assert (
+            render_template_string(
+                '''<link rel="stylesheet" src="{{ manifest['unknown.css'] }}" />'''
+            )
+            == render_template_string(
+                '''<link rel="stylesheet" src="{{ manifest('unknown.css') }}" />'''
+            )
+            == render_template_string(
+                '''<link rel="stylesheet" src="{{ manifest.get('unknown.css','''
+                ''' 'data:,') }}" />'''
+            )
+            == render_template_string(
+                '''<link rel="stylesheet" src="{{ 'unknown.css'|manifest }}" />'''
+            )
+            == '<link rel="stylesheet" src="data:," />'
+        )

--- a/tests/coaster_tests/test-manifest.json
+++ b/tests/coaster_tests/test-manifest.json
@@ -1,6 +1,6 @@
 {
-  "test.css": "test-file-does-not-really-exist.css",
-  "index.scss": "this-is-index.css",
+  "test.css": "test-asset.css",
+  "index.scss": "test-index.css",
   "test.js": "js/test.js",
   "test.png": "img/test.png",
   "test.jpg": "img/test.jpg"

--- a/tests/coaster_tests/test-manifest.json
+++ b/tests/coaster_tests/test-manifest.json
@@ -1,0 +1,7 @@
+{
+  "test.css": "test-file-does-not-really-exist.css",
+  "index.scss": "this-is-index.css",
+  "test.js": "js/test.js",
+  "test.png": "img/test.png",
+  "test.jpg": "img/test.jpg"
+}


### PR DESCRIPTION
The WebpackManifest extension loads a Webpack `manifest.json` file from the app's static folder and makes itself available under the `manifest` name to Jinja2 templates.

Some decisions in this first cut are questionable and may need revision:

1. The default search paths are `static/manifest.json` and `static/build/manifest.json`. The `build` subfolder is a convention in Hasgeek apps but not a Flask convention. Should the `search_paths` parameter be discarded in favour of a simple `path`, defaulting to only `static/manifest.json`?

2. Dictionary access in the form `manifest['asset-name.ext']` will return a default value of `data:,` instead of raising KeyError, making this behaviour different from a regular dict and a bit like using `defaultdict(lambda: 'data:,')`. Call access simply proxies to dict access. Should we reserve this default behaviour for call access and make dict access behave like an ordinary dict?

3. The default value `data:,` mimics a URI with no content. It is meant to avoid raising an exception in call access (which will cause a 500 server error), instead causing only one linked resource to go missing in the browser. However, this failure is not logged, so errors could creep into production unnoticed. This behaviour is similar to what happens with dict access — Jinja2 substitutes KeyError with an Undefined object, causing a silent failure. Should we log an error when an asset is not found so it comes to notice? Note that if `__getitem__` raises a KeyError without logging it, Jinja2 will swallow the exception and it will continue to cause silent failures.

4. We install both a Jinja2 global function and a filter. Jinja2 considers them separate namespaces. Syntax in the form `{{ 'asset-name.ext'|manifest }}` is likely an abuse of what filters are meant for. Should we remove the filter?

5. WebpackManifest does not allow customisation of the Jinja2 global or the location where it stores data. Should these be configurable, or will that cause other oversight problems when a weird value is used?