### PR TITLE
Specify target attribute type in DynamicAssociationProxy

### DIFF
--- a/tests/coaster_tests/sqlalchemy_roles_test.py
+++ b/tests/coaster_tests/sqlalchemy_roles_test.py
@@ -199,7 +199,7 @@ class RelationshipParent(BaseNameMixin, Model):
             'children_dict_attr,children_list,children_list_lazy,children_set,parent'
         ),
     )
-    children_names = DynamicAssociationProxy('children_list_lazy', 'name')
+    children_names = DynamicAssociationProxy[str]('children_list_lazy', 'name')
 
     __roles__ = {
         'all': {


### PR DESCRIPTION
To aid static type analysis, `DynamicAssociationProxy` is now a generic that accepts the type of the target attribute.