### PR TITLE
Modernize ClassView and ModelView

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import sys
 import typing as t
 
 sys.path.insert(0, os.path.abspath('../src'))
-from coaster import _version  # isort:skip  # pylint: disable=wrong-import-position
+from coaster import _version  # isort:skip
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/src/coaster/app.py
+++ b/src/coaster/app.py
@@ -330,11 +330,10 @@ def load_config_from_file(
     try:
         if load is None:
             return app.config.from_pyfile(filepath)
-        # The `text` parameter requires Flask 2.3. We still support Flask 2.2
+        # The `text` parameter was introduced in Flask 2.3, but its default value
+        # may change in a future release, so we only supply a value if we have a bool
         if text is not None:
-            return app.config.from_file(  # type: ignore[call-arg]
-                filepath, load=load, text=text
-            )
+            return app.config.from_file(filepath, load=load, text=text)
         return app.config.from_file(filepath, load=load)
     except OSError:
         app.logger.warning(

--- a/src/coaster/app.py
+++ b/src/coaster/app.py
@@ -106,7 +106,7 @@ _sentinel_keyrotation_exception = RuntimeError("KeyRotationWrapper has no engine
 # --- Key rotation wrapper -------------------------------------------------------------
 
 
-class KeyRotationWrapper(t.Generic[_S]):  # pylint: disable=too-few-public-methods
+class KeyRotationWrapper(t.Generic[_S]):
     """
     Wrapper to support multiple secret keys in itsdangerous.
 

--- a/src/coaster/app.py
+++ b/src/coaster/app.py
@@ -40,7 +40,7 @@ mod_tomllib: t.Optional[types.ModuleType] = None
 mod_tomli: t.Optional[types.ModuleType] = None
 mod_yaml: t.Optional[types.ModuleType] = None
 
-try:  # pragma: no cover
+try:
     import toml as mod_toml  # type: ignore[no-redef,unused-ignore]
 except ModuleNotFoundError:
     try:
@@ -52,7 +52,7 @@ except ModuleNotFoundError:
             pass
 
 
-try:  # pragma: no cover
+try:
     import yaml as mod_yaml
 except ModuleNotFoundError:
     pass

--- a/src/coaster/app.py
+++ b/src/coaster/app.py
@@ -193,7 +193,7 @@ class JSONProvider(DefaultJSONProvider):
 
     @staticmethod
     def default(o: t.Any) -> t.Any:
-        """Expand default support to check for `__json__`."""
+        """Expand default support to check for a ``__json__`` method."""
         if hasattr(o, '__json__'):
             return o.__json__()
         if isinstance(o, abc.Mapping):

--- a/src/coaster/db.py
+++ b/src/coaster/db.py
@@ -19,12 +19,12 @@ from sqlalchemy.engine import Engine
 
 from .sqlalchemy import Query
 
-try:  # pragma: no cover
+try:
     from psycopg2.extensions import connection as Psycopg2Connection  # noqa: N812
 except ModuleNotFoundError:
     Psycopg2Connection = None
 
-try:  # pragma: no cover
+try:
     from psycopg import Connection as Psycopg3Connection
 except ModuleNotFoundError:
     Psycopg3Connection = None  # type: ignore[assignment,misc]

--- a/src/coaster/logger.py
+++ b/src/coaster/logger.py
@@ -32,7 +32,7 @@ import requests
 from flask import g, request, session
 from flask.config import Config
 
-try:  # Flask >= 3.0  # pragma: no cover
+try:  # Flask >= 3.0
     from flask.sansio.app import App as FlaskApp
 except ModuleNotFoundError:
     from flask import Flask as FlaskApp

--- a/src/coaster/sqlalchemy/functions.py
+++ b/src/coaster/sqlalchemy/functions.py
@@ -87,17 +87,17 @@ session_type = t.Union[sa.orm.Session, sa.orm.scoped_session]
 
 
 @overload
-def failsafe_add(__session: session_type, __instance: t.Any) -> None:
+def failsafe_add(__session: session_type, __instance: t.Any, /) -> None:
     ...
 
 
 @overload
-def failsafe_add(__session: session_type, __instance: T, **filters: t.Any) -> T:
+def failsafe_add(__session: session_type, __instance: T, /, **filters: t.Any) -> T:
     ...
 
 
 def failsafe_add(
-    __session: session_type, __instance: T, **filters: t.Any
+    __session: session_type, __instance: T, /, **filters: t.Any
 ) -> t.Optional[T]:
     """
     Add and commit a new instance in a nested transaction (using SQL SAVEPOINT).

--- a/src/coaster/sqlalchemy/markdown.py
+++ b/src/coaster/sqlalchemy/markdown.py
@@ -92,10 +92,6 @@ class MarkdownComposite(MutableComposite):
             self.__composite_values__() == other.__composite_values__()
         )
 
-    def __ne__(self, other: t.Any) -> bool:
-        """Compare for inequality."""
-        return not self.__eq__(other)
-
     # Pickle support methods implemented as per SQLAlchemy documentation, but not
     # tested here as we don't use them.
     # https://docs.sqlalchemy.org/en/13/orm/extensions/mutable.html#id1

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -150,7 +150,7 @@ class IdMixin(t.Generic[PkeyType]):
             # XXX: Is this the correct way to examine a generic subclass that may have
             # more generic args in a redefined order? The docs suggest Generic args are
             # assumed positional, but they may be reordered, so how do we determine the
-            # arg to IdMixin itself? There is no variant of `cls.mro()` that returns
+            # arg to IdMixin itself? There is no variant of `cls.__mro__` that returns
             # original base classes with their generic args. For now, we expect that
             # generic subclasses _must_ use the static `PkeyType` typevar in their
             # definitions. This may need to be revisited with Python 3.12's new type

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -1137,7 +1137,7 @@ class BaseScopedIdMixin(BaseMixin[PkeyType]):
     def make_id(self) -> None:
         """Create a new URL id that is unique to the parent container."""
         if self.url_id is None:  # Set id only if empty
-            self.url_id = (  # type: ignore[unreachable]
+            self.url_id = (
                 # pylint: disable=not-callable
                 select(func.coalesce(func.max(self.__class__.url_id + 1), 1))
                 .where(

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -22,8 +22,6 @@ Mixin classes must always appear *before* ``Model`` or ``db.Model`` in your mode
 base classes.
 """
 
-# pylint: disable=too-few-public-methods,no-self-argument
-
 from __future__ import annotations
 
 import typing as t
@@ -197,6 +195,7 @@ class IdMixin(t.Generic[PkeyType]):
 
     @immutable
     @declared_attr
+    @classmethod
     def id(cls) -> Mapped[PkeyType]:  # noqa: A003
         """Database identity for this model."""
         if cls.__uuid_primary_key__:
@@ -207,6 +206,7 @@ class IdMixin(t.Generic[PkeyType]):
         return sa.orm.mapped_column(sa.Integer, primary_key=True, nullable=False)
 
     @declared_attr
+    @classmethod
     def url_id(cls) -> Mapped[str]:
         """URL-safe representation of the id value, using hex for a UUID id."""
         if cls.__uuid_primary_key__:
@@ -320,6 +320,7 @@ class UuidMixin:
         self.uuid = uuid_from_base58(value)
 
     @uuid_b58.inplace.comparator
+    @classmethod
     def _uuid_b58_comparator(cls) -> SqlUuidB58Comparator:
         """Return SQL comparator for UUID in Base58 format."""
         return SqlUuidB58Comparator(cls.uuid)
@@ -338,6 +339,7 @@ class TimestampMixin:
 
     @immutable
     @declared_attr
+    @classmethod
     def created_at(cls) -> Mapped[datetime]:
         """Timestamp for when this instance was created, in UTC."""
         return sa.orm.mapped_column(
@@ -347,6 +349,7 @@ class TimestampMixin:
         )
 
     @declared_attr
+    @classmethod
     def updated_at(cls) -> Mapped[datetime]:
         """Timestamp for when this instance was last updated (via the app), in UTC."""
         return sa.orm.mapped_column(
@@ -702,6 +705,7 @@ class BaseNameMixin(BaseMixin[PkeyType]):
     __title_length__: t.ClassVar[t.Optional[int]] = 250
 
     @declared_attr
+    @classmethod
     def name(cls) -> Mapped[str]:
         """Column for URL name of this object, unique across all instances."""
         if cls.__name_length__ is None:
@@ -715,6 +719,7 @@ class BaseNameMixin(BaseMixin[PkeyType]):
         )
 
     @declared_attr
+    @classmethod
     def title(cls) -> Mapped[str]:
         """Column for title of this object."""
         if cls.__title_length__ is None:
@@ -852,6 +857,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType]):
     parent: t.Any
 
     @declared_attr
+    @classmethod
     def name(cls) -> Mapped[str]:
         """Column for URL name of this object, unique within a parent container."""
         if cls.__name_length__ is None:
@@ -865,6 +871,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType]):
         )
 
     @declared_attr
+    @classmethod
     def title(cls) -> Mapped[str]:
         """Column for title of this object."""
         if cls.__title_length__ is None:
@@ -1016,6 +1023,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType]):
     __title_length__: t.ClassVar[t.Optional[int]] = 250
 
     @declared_attr
+    @classmethod
     def name(cls) -> Mapped[str]:
         """Column for the URL name of this object, non-unique."""
         if cls.__name_length__ is None:
@@ -1029,6 +1037,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType]):
         )
 
     @declared_attr
+    @classmethod
     def title(cls) -> Mapped[str]:
         """Column for the title of this object."""
         if cls.__title_length__ is None:
@@ -1128,6 +1137,7 @@ class BaseScopedIdMixin(BaseMixin[PkeyType]):
     # FIXME: Rename this to `scoped_id` and provide a migration guide.
     @with_roles(read={'all'})
     @declared_attr
+    @classmethod
     def url_id(cls) -> Mapped[int]:  # type: ignore[override]
         """Column for an id number that is unique within the parent container."""
         return sa.orm.mapped_column(sa.Integer, nullable=False)
@@ -1211,6 +1221,7 @@ class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType]):
     __title_length__: t.ClassVar[t.Optional[int]] = 250
 
     @declared_attr
+    @classmethod
     def name(cls) -> Mapped[str]:
         """Column for the URL name of this instance, non-unique."""
         if cls.__name_length__ is None:
@@ -1224,6 +1235,7 @@ class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType]):
         )
 
     @declared_attr
+    @classmethod
     def title(cls) -> Mapped[str]:
         """Column for the title of this instance."""
         if cls.__title_length__ is None:

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -707,7 +707,7 @@ class BaseNameMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def name(cls) -> Mapped[str]:
-        """Column for URL name of this object, unique across all instances."""
+        """URL name of this object, unique across all instances."""
         if cls.__name_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -721,7 +721,7 @@ class BaseNameMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def title(cls) -> Mapped[str]:
-        """Column for title of this object."""
+        """Title of this object."""
         if cls.__title_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -859,7 +859,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def name(cls) -> Mapped[str]:
-        """Column for URL name of this object, unique within a parent container."""
+        """URL name of this object, unique within the parent container."""
         if cls.__name_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -873,7 +873,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def title(cls) -> Mapped[str]:
-        """Column for title of this object."""
+        """Title of this object."""
         if cls.__title_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -1025,7 +1025,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def name(cls) -> Mapped[str]:
-        """Column for the URL name of this object, non-unique."""
+        """URL name of this object, non-unique."""
         if cls.__name_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -1039,7 +1039,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def title(cls) -> Mapped[str]:
-        """Column for the title of this object."""
+        """Title of this object."""
         if cls.__title_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -1139,7 +1139,7 @@ class BaseScopedIdMixin(BaseMixin[PkeyType]):
     @declared_attr
     @classmethod
     def url_id(cls) -> Mapped[int]:  # type: ignore[override]
-        """Column for an id number that is unique within the parent container."""
+        """Id number that is unique within the parent container."""
         return sa.orm.mapped_column(sa.Integer, nullable=False)
 
     def __init__(self, *args, **kw) -> None:
@@ -1223,7 +1223,7 @@ class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType]):
     @declared_attr
     @classmethod
     def name(cls) -> Mapped[str]:
-        """Column for the URL name of this instance, non-unique."""
+        """URL name of this object, non-unique."""
         if cls.__name_length__ is None:
             column_type = sa.Unicode()
         else:
@@ -1237,7 +1237,7 @@ class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType]):
     @declared_attr
     @classmethod
     def title(cls) -> Mapped[str]:
-        """Column for the title of this instance."""
+        """Title of this object."""
         if cls.__title_length__ is None:
             column_type = sa.Unicode()
         else:

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -91,8 +91,6 @@ __all__ = [
     'RegistryMixin',
 ]
 
-_T = t.TypeVar('_T', bound=t.Any)
-
 PkeyType = te.TypeVar('PkeyType', int, UUID, default=int)
 # `default=int` is processed by type checkers implementing PEP 696, but seemingly has no
 # impact in runtime, so no default will be received in `IdMixin.__init_subclass__`

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -36,7 +36,7 @@ from uuid import UUID, uuid4
 
 from flask import current_app, url_for
 
-try:  # Flask >= 3.0  # pragma: no cover
+try:  # Flask >= 3.0
     from flask.sansio.app import App as FlaskApp
 except ModuleNotFoundError:  # Flask < 3.0
     from flask import Flask as FlaskApp

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -540,6 +540,7 @@ class UrlForMixin:
         __action: str,
         __endpoint: t.Optional[str] = None,
         __app: t.Optional[FlaskApp] = None,
+        /,
         _external: t.Optional[bool] = None,
         **paramattrs: t.Union[str, t.Tuple[str, ...], t.Callable[[t.Any], str]],
     ) -> ReturnDecorator:
@@ -569,6 +570,7 @@ class UrlForMixin:
     def register_endpoint(
         cls,
         action: str,
+        *,
         endpoint: str,
         app: t.Optional[FlaskApp],
         paramattrs: t.Mapping[

--- a/src/coaster/sqlalchemy/model.py
+++ b/src/coaster/sqlalchemy/model.py
@@ -318,7 +318,7 @@ class ModelBase:
         #    __init_subclass__ scanned it. We can't stop a programmer from shooting
         #   their own foot. At best, we can warn of an accidental error.
         bind_key = cls.__bind_key__
-        for base in cls.mro():
+        for base in cls.__mro__:
             if ModelBase in base.__bases__:
                 # We've found the direct subclass of ModelBase...
                 base = cast(t.Type[ModelBase], base)  # ...but Mypy doesn't know yet

--- a/src/coaster/sqlalchemy/model.py
+++ b/src/coaster/sqlalchemy/model.py
@@ -270,7 +270,7 @@ class AppenderQuery(  # type: ignore[misc]  # pylint: disable=abstract-method
     """
 
     # AppenderMixin does not specify a type for query_class
-    query_class = Query  # type: ignore[assignment]
+    query_class = Query
 
 
 class QueryProperty:

--- a/src/coaster/sqlalchemy/model.py
+++ b/src/coaster/sqlalchemy/model.py
@@ -121,9 +121,9 @@ class ModelWarning(UserWarning):
 
 bigint: te.TypeAlias = te.Annotated[int, mapped_column(sa.BigInteger())]
 smallint: te.TypeAlias = te.Annotated[int, mapped_column(sa.SmallInteger())]
-int_pkey: te.TypeAlias = te.Annotated[int, mapped_column(primary_key=True, init=False)]
+int_pkey: te.TypeAlias = te.Annotated[int, mapped_column(primary_key=True)]
 uuid4_pkey: te.TypeAlias = te.Annotated[
-    uuid.UUID, mapped_column(primary_key=True, default=uuid.uuid4, init=False)
+    uuid.UUID, mapped_column(primary_key=True, default=uuid.uuid4)
 ]
 timestamp: te.TypeAlias = te.Annotated[
     datetime.datetime, mapped_column(sa.TIMESTAMP(timezone=True))

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -43,6 +43,7 @@ Example use::
             return sa.orm.mapped_column(sa.Unicode(250))
 
         @declared_attr
+        @classmethod
         def mixed_in2(cls) -> Mapped[str]:
             return with_roles(sa.orm.mapped_column(sa.Unicode(250)), rw={'owner'})
 

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -580,19 +580,25 @@ class LazyRoleSet(abc.MutableSet):
         result._not_present = set(self._not_present)  # pylint: disable=protected-access
         return result
 
+    # Sets offer these names as synonyms for operators
+    issubset = abc.MutableSet.__le__
+    issuperset = abc.MutableSet.__ge__
+    symmetric_difference_update = abc.MutableSet.__ixor__
+
     # Set operators take a single `other` parameter while these methods
     # are required to take multiple `others` to be API-compatible with sets.
     # `nary_op` converts a binary operator to an n-ary operator
-    issubset = nary_op(abc.MutableSet.__le__)
-    issuperset = nary_op(abc.MutableSet.__ge__)
     union = nary_op(abc.MutableSet.__or__)
     intersection = nary_op(__and__)
     difference = nary_op(abc.MutableSet.__sub__)
     symmetric_difference = nary_op(abc.MutableSet.__xor__)
-    update = nary_op(abc.MutableSet.__ior__)
-    intersection_update = nary_op(abc.MutableSet.__iand__)
-    difference_update = nary_op(abc.MutableSet.__isub__)
-    symmetric_difference_update = nary_op(abc.MutableSet.__ixor__)
+    update: t.ClassVar[t.Callable[..., te.Self]] = nary_op(abc.MutableSet.__ior__)
+    intersection_update: t.ClassVar[t.Callable[..., te.Self]] = nary_op(
+        abc.MutableSet.__iand__
+    )
+    difference_update: t.ClassVar[t.Callable[..., te.Self]] = nary_op(
+        abc.MutableSet.__isub__
+    )
 
 
 class DynamicAssociationProxy(t.Generic[_V]):

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -538,9 +538,6 @@ class LazyRoleSet(abc.MutableSet):
             return self.obj == other.obj and self.actor == other.actor
         return self._contents() == other
 
-    def __ne__(self, other: t.Any) -> bool:
-        return not self.__eq__(other)
-
     def __and__(self, other: t.Iterable[str]) -> t.Set[str]:
         """Faster implementation that avoids lazy lookups where not needed."""
         return {role for role in other if self._role_is_present(role)}
@@ -713,10 +710,6 @@ class DynamicAssociationProxyWrapper(abc.Set, t.Generic[_V, _T]):
             and self.rel == other.rel
             and self.attr == other.attr
         )
-
-    def __ne__(self, other: t.Any) -> bool:
-        # This method is required as abc.Set provides a less efficient version
-        return not self.__eq__(other)
 
 
 class RoleAccessProxy(abc.Mapping, t.Generic[RoleMixinType]):
@@ -985,10 +978,6 @@ class RoleAccessProxy(abc.Mapping, t.Generic[RoleMixinType]):
         ):
             return True
         return super().__eq__(other)
-
-    def __ne__(self, other: t.Any) -> bool:
-        # Don't call __eq__ directly, it may return NotImplemented
-        return not self == other
 
     def __bool__(self) -> bool:
         return bool(self._obj)

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -1007,7 +1007,7 @@ def with_roles(
 @overload
 def with_roles(
     __obj: _DA,
-    *,
+    /,
     rw: t.Optional[t.Set[str]] = None,
     call: t.Optional[t.Set[str]] = None,
     read: t.Optional[t.Set[str]] = None,
@@ -1026,7 +1026,7 @@ def with_roles(
 
 def with_roles(
     __obj: t.Optional[_DA] = None,
-    *,
+    /,
     rw: t.Optional[t.Set[str]] = None,
     call: t.Optional[t.Set[str]] = None,
     read: t.Optional[t.Set[str]] = None,

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -128,6 +128,7 @@ Example use::
 from __future__ import annotations
 
 import dataclasses
+import sys
 import typing as t
 import typing_extensions as te
 from abc import ABCMeta, abstractmethod
@@ -169,6 +170,7 @@ __all__ = [
     'RoleAccessProxy',
     'DynamicAssociationProxy',
     'RoleMixin',
+    'WithRoles',
     'with_roles',
 ]
 
@@ -207,6 +209,9 @@ class RoleAttrs(te.TypedDict, total=False):
 class WithRoles:
     """Role annotations for an attribute."""
 
+    if sys.version_info >= (3, 10):
+        _: dataclasses.KW_ONLY
+
     read: t.Set[str] = dataclasses.field(default_factory=set)
     write: t.Set[str] = dataclasses.field(default_factory=set)
     call: t.Set[str] = dataclasses.field(default_factory=set)
@@ -229,7 +234,7 @@ class WithRoles:
             write=self.write | other.write,
             call=self.call | other.call,
             grants=self.grants | other.grants,
-            grants_via={**self.grants_via, **other.grants_via},
+            grants_via=self.grants_via | other.grants_via,
             datasets=self.datasets | other.datasets,
         )
 

--- a/src/coaster/sqlalchemy/statemanager.py
+++ b/src/coaster/sqlalchemy/statemanager.py
@@ -302,7 +302,7 @@ class StateTransitionError(BadRequest, TypeError):
     """Raised if a transition is attempted from a non-matching state."""
 
 
-class AbortTransition(Exception):  # noqa: N818
+class AbortTransition(BaseException):
     """
     Transitions may raise :exc:`AbortTransition` to return without changing state.
 
@@ -314,10 +314,9 @@ class AbortTransition(Exception):  # noqa: N818
     :param result: Value to return to the transition's caller
     """
 
-    def __init__(  # pylint: disable=useless-super-delegation
-        self, result: t.Any = None
-    ) -> None:
-        super().__init__(result)
+    def __init__(self, result: t.Any = None) -> None:
+        super().__init__()
+        self.result = result
 
 
 # --- Classes --------------------------------------------------------------------------
@@ -713,7 +712,7 @@ class StateTransitionWrapper(t.Generic[_P, _R, _T]):
             transition_exception.send(
                 self.obj, transition=self.statetransition, exception=e
             )
-            return e.args[0]
+            return e.result
         except Exception as e:  # noqa: B902
             transition_exception.send(
                 self.obj, transition=self.statetransition, exception=e

--- a/src/coaster/sqlalchemy/statemanager.py
+++ b/src/coaster/sqlalchemy/statemanager.py
@@ -520,9 +520,6 @@ class ManagedStateInstance(t.Generic[_T]):
             and self._obj == other._obj
         )
 
-    def __ne__(self, other: t.Any) -> bool:
-        return not self.__eq__(other)
-
     def __bool__(self) -> bool:
         return self._mstate.is_current_in(self._obj)
 

--- a/src/coaster/typing.py
+++ b/src/coaster/typing.py
@@ -6,8 +6,29 @@ Coaster types
 from __future__ import annotations
 
 import typing as t
+import typing_extensions as te
 
 #: Type used for functions and methods wrapped in a decorator
 WrappedFunc = t.TypeVar('WrappedFunc', bound=t.Callable)
 #: Return type for decorator factories
 ReturnDecorator = t.Callable[[WrappedFunc], WrappedFunc]
+
+#: Recurring use ParamSpec
+P = te.ParamSpec('P')
+#: Recurring use type spec
+T = t.TypeVar('T')
+
+
+class MethodProtocol(te.Protocol[P, T]):
+    """
+    Protocol that matches a method without also matching against a type constructor.
+
+    Replace ``Callable[Concatenate[Any, P], T]`` with ``MethodProtocol[Concatenate[Any,
+    P], T]``. This is needed because the typeshed defines ``type.__call__``, so any type
+    will also validate as a callable. Mypy special-cases callable protocols as not
+    matching ``type.__call__`` in https://github.com/python/mypy/pull/14121.
+    """
+
+    # Using ``def __call__`` seems to break Mypy, so we use this hack
+    # https://github.com/python/typing/discussions/1312#discussioncomment-4416217
+    __call__: t.Callable[te.Concatenate[t.Any, P], T]

--- a/src/coaster/typing.py
+++ b/src/coaster/typing.py
@@ -14,21 +14,21 @@ WrappedFunc = t.TypeVar('WrappedFunc', bound=t.Callable)
 ReturnDecorator = t.Callable[[WrappedFunc], WrappedFunc]
 
 #: Recurring use ParamSpec
-P = te.ParamSpec('P')
+_P = te.ParamSpec('_P')
 #: Recurring use type spec
-T = t.TypeVar('T')
+_T = t.TypeVar('_T')
 
 
-class MethodProtocol(te.Protocol[P, T]):
+class MethodProtocol(te.Protocol[_P, _T]):
     """
     Protocol that matches a method without also matching against a type constructor.
 
-    Replace ``Callable[Concatenate[Any, P], T]`` with ``MethodProtocol[Concatenate[Any,
-    P], T]``. This is needed because the typeshed defines ``type.__call__``, so any type
+    Replace ``Callable[Concatenate[Any, P], R]`` with ``MethodProtocol[Concatenate[Any,
+    P], R]``. This is needed because the typeshed defines ``type.__call__``, so any type
     will also validate as a callable. Mypy special-cases callable protocols as not
     matching ``type.__call__`` in https://github.com/python/mypy/pull/14121.
     """
 
     # Using ``def __call__`` seems to break Mypy, so we use this hack
     # https://github.com/python/typing/discussions/1312#discussioncomment-4416217
-    __call__: t.Callable[te.Concatenate[t.Any, P], T]
+    __call__: t.Callable[te.Concatenate[t.Any, _P], _T]

--- a/src/coaster/utils/misc.py
+++ b/src/coaster/utils/misc.py
@@ -670,16 +670,13 @@ def domain_namespace_match(domain: str, namespace: str) -> bool:
 
 
 T = t.TypeVar('T')
+T2 = t.TypeVar('T2')
+R_co = t.TypeVar('R_co', covariant=True)
 
 
-class _CallableSameArgs(te.Protocol):
-    """Protocol for callable that accepts multiple arguments of the same type."""
-
-    def __call__(self, lhs: T, *others: T) -> T:
-        ...
-
-
-def nary_op(f: t.Callable, doc: t.Optional[str] = None) -> _CallableSameArgs:
+def nary_op(
+    f: t.Callable[[T, T2], R_co], doc: t.Optional[str] = None
+) -> t.Callable[..., R_co]:
     """
     Convert a binary operator function into a chained n-ary operator.
 
@@ -696,10 +693,10 @@ def nary_op(f: t.Callable, doc: t.Optional[str] = None) -> _CallableSameArgs:
     """
 
     @wraps(f)
-    def inner(lhs: T, *others: T) -> T:
+    def inner(lhs: T, *others: T2) -> R_co:
         for other in others:
-            lhs = f(lhs, other)
-        return lhs
+            lhs = f(lhs, other)  # type: ignore[assignment]
+        return lhs  # type: ignore[return-value]
 
     if doc is not None:
         inner.__doc__ = doc

--- a/src/coaster/utils/misc.py
+++ b/src/coaster/utils/misc.py
@@ -512,17 +512,19 @@ def nullstr(value: t.Optional[t.Any]) -> t.Optional[str]:
 
 
 @overload
-def require_one_of(__return: te.Literal[False] = False, **kwargs: t.Any) -> None:
+def require_one_of(__return: te.Literal[False] = False, /, **kwargs: t.Any) -> None:
     ...
 
 
 @overload
-def require_one_of(__return: te.Literal[True], **kwargs: t.Any) -> t.Tuple[str, t.Any]:
+def require_one_of(
+    __return: te.Literal[True], /, **kwargs: t.Any
+) -> t.Tuple[str, t.Any]:
     ...
 
 
 def require_one_of(
-    __return: bool = False, **kwargs: t.Any
+    __return: bool = False, /, **kwargs: t.Any
 ) -> t.Optional[t.Tuple[str, t.Any]]:
     """
     Validate that only one of multiple parameters has a non-None value.
@@ -540,10 +542,9 @@ def require_one_of(
             # Carry on with function logic
             pass
 
-    :param __return: Return the matching parameter name and value (positional only)
+    :param __return: Return the matching parameter name and value
     :param kwargs: Parameters, of which one and only one is mandatory
     :return: If `__return`, matching parameter name and value
-    :rtype: tuple
     :raises TypeError: If the count of parameters that aren't ``None`` is not 1
 
     .. deprecated:: 0.7.0

--- a/src/coaster/utils/misc.py
+++ b/src/coaster/utils/misc.py
@@ -672,8 +672,8 @@ def domain_namespace_match(domain: str, namespace: str) -> bool:
 T = t.TypeVar('T')
 
 
-class _CallableSameArgs(te.Protocol):  # pylint: disable=too-few-public-methods
-    """Protocl for callable that accepts multiple arguments of the same type."""
+class _CallableSameArgs(te.Protocol):
+    """Protocol for callable that accepts multiple arguments of the same type."""
 
     def __call__(self, lhs: T, *others: T) -> T:
         ...

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -77,22 +77,22 @@ class RouteDecoratorProtocol(te.Protocol):
     """Protocol for the decorator returned by ``@route(...)``."""
 
     @t.overload
-    def __call__(self, decorated: ClassViewType) -> ClassViewType:
+    def __call__(self, __decorated: ClassViewType) -> ClassViewType:
         ...
 
     @t.overload
-    def __call__(self, decorated: ViewMethod[P, R_co]) -> ViewMethod[P, R_co]:
+    def __call__(self, __decorated: ViewMethod[P, R_co]) -> ViewMethod[P, R_co]:
         ...
 
     @t.overload
     def __call__(
-        self, decorated: MethodProtocol[te.Concatenate[t.Any, P], R_co]
+        self, __decorated: MethodProtocol[te.Concatenate[t.Any, P], R_co]
     ) -> ViewMethod[P, R_co]:
         ...
 
     def __call__(
         self,
-        decorated: t.Union[
+        __decorated: t.Union[
             ClassViewType,
             MethodProtocol[te.Concatenate[t.Any, P], R_co],
             ViewMethod[P, R_co],
@@ -105,18 +105,18 @@ class ViewDataDecoratorProtocol(te.Protocol):
     """Protocol for the decorator returned by ``@viewdata(...)``."""
 
     @t.overload
-    def __call__(self, decorated: ViewMethod[P, R_co]) -> ViewMethod[P, R_co]:
+    def __call__(self, __decorated: ViewMethod[P, R_co]) -> ViewMethod[P, R_co]:
         ...
 
     @t.overload
     def __call__(
-        self, decorated: MethodProtocol[te.Concatenate[t.Any, P], R_co]
+        self, __decorated: MethodProtocol[te.Concatenate[t.Any, P], R_co]
     ) -> ViewMethod[P, R_co]:
         ...
 
     def __call__(
         self,
-        decorated: t.Union[
+        __decorated: t.Union[
             MethodProtocol[te.Concatenate[t.Any, P], R_co], ViewMethod[P, R_co]
         ],
     ) -> ViewMethod[P, R_co]:
@@ -328,19 +328,19 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
         self.endpoint = owner.__name__ + '_' + self.name
 
     @overload
-    def __get__(self, obj: None, cls: t.Type) -> te.Self:
+    def __get__(self, obj: None, _cls: t.Type) -> te.Self:
         ...
 
     @overload
-    def __get__(self, obj: t.Any, cls: t.Type) -> ViewHandler[P, R_co]:
+    def __get__(self, obj: t.Any, _cls: t.Type) -> ViewHandler[P, R_co]:
         ...
 
     def __get__(
-        self, obj: t.Optional[t.Any], cls: t.Type
+        self, obj: t.Optional[t.Any], _cls: t.Type
     ) -> t.Union[te.Self, ViewHandler[P, R_co]]:
         if obj is None:
             return self
-        return ViewHandler(self, obj, cls)
+        return ViewHandler(self, obj)
 
     def __call__(  # pylint: disable=no-self-argument
         __self, self: ClassViewSubtype, *args: P.args, **kwargs: P.kwargs
@@ -385,7 +385,6 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
                 # https://github.com/python/mypy/issues/15822
                 this.view,  # type: ignore[arg-type]
                 viewinst,
-                this.view_class,
             )
             # Place view arguments in the instance, in case they are needed outside the
             # dispatch process
@@ -455,15 +454,13 @@ class ViewHandler(t.Generic[P, R_co]):
         self,
         view: ViewMethod[P, R_co],
         obj: ClassViewSubtype,
-        cls: t.Optional[ClassViewType],
     ) -> None:
         # obj is the ClassView instance
         self._view = view
         self._obj = obj
-        self._cls = cls
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R_co:
-        """Treat this like a call to the underlying method and not to the view."""
+        """Treat this like a call to the original method and not to the view."""
         # As per the __decorators__ spec, we call .func, not .wrapped_func
         return self._view.func(self._obj, *args, **kwargs)
 

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -18,7 +18,7 @@ from flask import abort, make_response, redirect, request
 from flask.globals import _cv_app, app_ctx
 from flask.typing import ResponseReturnValue
 
-try:  # Flask >= 3.0  # pragma: no cover
+try:  # Flask >= 3.0
     from flask.sansio.app import App as FlaskApp
     from flask.sansio.blueprints import Blueprint, BlueprintSetupState
 except ModuleNotFoundError:  # Flask < 3.0

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -824,15 +824,15 @@ class ModelView(ClassView, t.Generic[ModelType]):
         implementations must override :meth:`load` and be responsible for setting
         :attr:`obj`.
         """
-        self.obj = self.loader(**view_args)  # type: ignore[assignment]
+        self.obj = self.loader(**view_args)
         # Trigger pre-view processing of the loaded object
         return self.after_loader()
 
-    loader: t.Callable[..., t.Optional[ModelType]]
+    loader: t.Callable[..., ModelType]
 
     def loader(  # type: ignore[no-redef]  # pragma: no cover
         self, **view_args
-    ) -> t.Optional[ModelType]:
+    ) -> ModelType:
         """
         Load database object and return it.
 

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -1089,7 +1089,9 @@ class UrlChangeCheck:  # pylint: disable=too-few-public-methods
                 return self.obj.current_access()
     """
 
-    __decorators__: t.List[t.Callable[[t.Callable], t.Callable]] = [url_change_check]
+    __decorators__: t.ClassVar[t.List[t.Callable[[t.Callable], t.Callable]]] = [
+        url_change_check
+    ]
 
 
 class InstanceLoader:  # pylint: disable=too-few-public-methods

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -663,9 +663,6 @@ class ClassView:
     def __eq__(self, other: t.Any) -> bool:
         return type(other) is type(self)
 
-    def __ne__(self, other: t.Any) -> bool:
-        return type(other) is not type(self)
-
     def dispatch_request(
         self, view: t.Callable[..., ResponseReturnValue], view_args: t.Dict[str, t.Any]
     ) -> BaseResponse:
@@ -953,9 +950,6 @@ class ModelView(ClassView, t.Generic[ModelType]):
 
     def __eq__(self, other: t.Any) -> bool:
         return type(other) is type(self) and other.obj == self.obj
-
-    def __ne__(self, other: t.Any) -> bool:
-        return not self.__eq__(other)
 
     def dispatch_request(
         self, view: t.Callable[..., ResponseReturnValue], view_args: t.Dict[str, t.Any]

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -90,7 +90,7 @@ class RouteDecoratorProtocol(te.Protocol):
     ) -> ViewMethod[P, R_co]:
         ...
 
-    def __call__(
+    def __call__(  # skipcq: PTC-W0049
         self,
         __decorated: t.Union[
             ClassViewType,
@@ -114,7 +114,7 @@ class ViewDataDecoratorProtocol(te.Protocol):
     ) -> ViewMethod[P, R_co]:
         ...
 
-    def __call__(
+    def __call__(  # skipcq: PTC-W0049
         self,
         __decorated: t.Union[
             MethodProtocol[te.Concatenate[t.Any, P], R_co], ViewMethod[P, R_co]

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -856,7 +856,7 @@ class ModelView(ClassView, t.Generic[ModelType]):
         model: t.Type[ModelType]
     else:
         #: The model that is being handled by this ModelView (autoset from Generic arg).
-        model: t.ClassVar[t.Type]
+        model: t.ClassVar[t.Type[ModelType]]
 
     #: A loaded object of the model's type
     obj: ModelType

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -261,7 +261,7 @@ def rulejoin(class_rule: str, method_rule: str) -> str:
     )
 
 
-class ViewMethod(t.Generic[_P, _R_co]):  # pylint: disable=too-many-instance-attributes
+class ViewMethod(t.Generic[_P, _R_co]):
     """Internal object created by the :func:`route` and :func:`viewdata` decorators."""
 
     # No __slots__ in ViewMethod because it mimics a wrapped function and must reproduce
@@ -1097,7 +1097,7 @@ def requires_roles(roles: t.Set) -> tc.ReturnDecorator:
     return decorator
 
 
-class UrlForView:  # pylint: disable=too-few-public-methods
+class UrlForView:
     """
     Mixin class that registers view handler methods as views on the model.
 
@@ -1115,7 +1115,7 @@ class UrlForView:  # pylint: disable=too-few-public-methods
     ) -> None:
         """Register view on an app."""
 
-        def register_view_on_model(  # pylint: disable=too-many-arguments
+        def register_view_on_model(
             cls: t.Type[ModelView],
             callback: t.Optional[InitAppCallback],
             app: t.Union[FlaskApp, Blueprint],
@@ -1269,7 +1269,7 @@ def url_change_check(f: WrappedFunc) -> WrappedFunc:
     return cast(tc.WrappedFunc, async_wrapper if iscoroutinefunction(f) else wrapper)
 
 
-class UrlChangeCheck:  # pylint: disable=too-few-public-methods
+class UrlChangeCheck:
     """
     Check for changed URLs in a :class:`ModelView`.
 
@@ -1295,7 +1295,7 @@ class UrlChangeCheck:  # pylint: disable=too-few-public-methods
     ]
 
 
-class InstanceLoader:  # pylint: disable=too-few-public-methods
+class InstanceLoader:
     """
     Mixin class for :class:`ModelView` that loads an instance.
 
@@ -1316,7 +1316,6 @@ class InstanceLoader:  # pylint: disable=too-few-public-methods
 
     def loader(self, **view_args) -> t.Any:
         """Load instance based on view arguments."""
-        # pylint: disable=too-many-nested-blocks
         if any(name in self.route_model_map for name in view_args):
             # We have a URL route attribute that matches one of the model's attributes.
             # Attempt to load the model instance

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -200,9 +200,7 @@ def route(rule: str, **options) -> RouteDecoratorProtocol:
     return decorator
 
 
-def viewdata(
-    **kwargs,
-) -> ViewDataDecoratorProtocol:
+def viewdata(**kwargs) -> ViewDataDecoratorProtocol:
     """
     Decorate view to add additional data alongside :func:`route`.
 
@@ -285,7 +283,7 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
         self.data = data or {}
         self.endpoints: t.Set[str] = set()
 
-        # Are we decorating another ViewHelper? If so, copy routes and func from it.
+        # Are we decorating another ViewMethod? If so, copy routes and func from it.
         if isinstance(decorated, ViewMethod):
             self.routes.extend(decorated.routes)
             newdata = dict(decorated.data)
@@ -368,6 +366,7 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
         * :attr:`endpoints`: The URL endpoints registered to this view handler
         """
 
+        # TODO: Move most of this into `__set_name__`
         def view_func(**view_args) -> BaseResponse:
             this = cast(ViewFuncProtocol, view_func)
             # view_func does not make any reference to variables from init_app to avoid
@@ -382,7 +381,7 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
             viewinst.current_handler = ViewHandler(
                 # Mypy is incorrectly applying the descriptor protocol to a non-class's
                 # dict, and therefore concluding this.view.__get__() -> ViewHandler,
-                # instead of this.view just remaining a ViewHelper, sans descriptor call
+                # instead of this.view just remaining a ViewMethod, sans descriptor call
                 # https://github.com/python/mypy/issues/15822
                 this.view,  # type: ignore[arg-type]
                 viewinst,

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -776,8 +776,6 @@ class ModelView(ClassView, t.Generic[ModelType]):
                 if origin_base is ModelView:
                     (model_type,) = t.get_args(base)
                     if model_type is not t.Any:
-                        if isinstance(model_type, tuple):
-                            model_type = model_type[0]
                         cls.model = model_type
                     break
         super().__init_subclass__()

--- a/src/coaster/views/classview.py
+++ b/src/coaster/views/classview.py
@@ -346,6 +346,7 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
     ) -> R_co:
         return __self.func(self, *args, **kwargs)
 
+    # TODO: Move most of this code into `__set_name__`
     def init_app(
         self,
         app: t.Union[FlaskApp, Blueprint],
@@ -366,7 +367,6 @@ class ViewMethod(t.Generic[P, R_co]):  # pylint: disable=too-many-instance-attri
         * :attr:`endpoints`: The URL endpoints registered to this view handler
         """
 
-        # TODO: Move most of this into `__set_name__`
         def view_func(**view_args) -> BaseResponse:
             this = cast(ViewFuncProtocol, view_func)
             # view_func does not make any reference to variables from init_app to avoid

--- a/src/coaster/views/decorators.py
+++ b/src/coaster/views/decorators.py
@@ -590,8 +590,8 @@ def render_with(
                         status_code = status_or_headers
                         headers = None
                 elif len(resultset) == 3:
-                    status_code = resultset[1]  # type: ignore[assignment,misc]
-                    headers = resultset[2]  # type: ignore[misc]
+                    status_code = resultset[1]
+                    headers = resultset[2]
                 else:
                     raise TypeError("View's response is an oversized tuple")
             else:

--- a/src/coaster/views/decorators.py
+++ b/src/coaster/views/decorators.py
@@ -257,7 +257,7 @@ def load_model(  # pylint: disable=too-many-arguments
 
         @app.route('/<profile>')
         @load_model(Profile, {'name': 'profile'}, 'profile')
-        def profile_view(profile):
+        def profile_view(profile: Profile):
             return f"Hello, {profile.name}"
 
     ``load_model`` aborts with a 404 if no instance is found.

--- a/src/coaster/views/decorators.py
+++ b/src/coaster/views/decorators.py
@@ -227,7 +227,7 @@ def requestbody(
     return requestargs(*args, source='body')
 
 
-def load_model(  # pylint: disable=too-many-arguments
+def load_model(
     model: t.Type,
     attributes: t.Dict[str, str],
     parameter: str,

--- a/src/coaster/views/misc.py
+++ b/src/coaster/views/misc.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import re
 import typing as t
+from inspect import iscoroutinefunction
 from typing import cast
 from urllib.parse import urlsplit
 
@@ -233,7 +234,7 @@ def ensure_sync(func: tc.WrappedFunc) -> tc.WrappedFunc:
     if current_app:
         return cast(tc.WrappedFunc, current_app.ensure_sync(func))
 
-    if not asyncio.iscoroutinefunction(func):
+    if not iscoroutinefunction(func):
         return func
 
     if async_to_sync is not None:

--- a/src/coaster/views/misc.py
+++ b/src/coaster/views/misc.py
@@ -27,7 +27,7 @@ from flask import (
 from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import MapAdapter, RequestRedirect, Rule
 
-try:  # pragma: no cover
+try:
     from asgiref.sync import async_to_sync
 except ModuleNotFoundError:
     async_to_sync = None  # type: ignore[assignment, misc]

--- a/tests/coaster_tests/auth_test.py
+++ b/tests/coaster_tests/auth_test.py
@@ -170,8 +170,8 @@ def test_current_auth_with_user(
     with pytest.raises(AttributeError):
         assert current_auth.fullname == 'Mr Foo'
 
-    # current_user is immutable
-    with pytest.raises(AttributeError):
+    # current_auth is immutable
+    with pytest.raises(TypeError, match="current_auth is read-only"):
         current_auth.username = 'bar'
 
     # For full attribute access, use the user object

--- a/tests/coaster_tests/auth_test.py
+++ b/tests/coaster_tests/auth_test.py
@@ -27,7 +27,7 @@ from .sqlalchemy_models_test import User
 # --- App context ----------------------------------------------------------------------
 
 
-class LoginManager:  # pylint: disable=too-few-public-methods
+class LoginManager:
     """Test login manager implementing _load_user method."""
 
     def __init__(self, _app: Flask) -> None:
@@ -48,7 +48,7 @@ class LoginManager:  # pylint: disable=too-few-public-methods
                 add_auth_attribute('username', self.user.username)
 
 
-class FlaskLoginManager(LoginManager):  # pylint: disable=too-few-public-methods
+class FlaskLoginManager(LoginManager):
     """Test login manager implementing _load_user but only setting ``g._login_user``."""
 
     def _load_user(self) -> None:

--- a/tests/coaster_tests/sqlalchemy_annotations_test.py
+++ b/tests/coaster_tests/sqlalchemy_annotations_test.py
@@ -301,18 +301,9 @@ class TestCoasterAnnotations(AppTestCase):
         )
 
         # Confirm there is no value for is_immutable
-        assert (
-            sa.inspect(pi1).attrs.is_immutable.loaded_value  # type: ignore[union-attr]
-            is NO_VALUE
-        )
-        assert (
-            sa.inspect(pi2).attrs.is_immutable.loaded_value  # type: ignore[union-attr]
-            is NO_VALUE
-        )
-        assert (
-            sa.inspect(pi3).attrs.is_immutable.loaded_value  # type: ignore[union-attr]
-            is NO_VALUE
-        )
+        assert sa.inspect(pi1).attrs.is_immutable.loaded_value is NO_VALUE
+        assert sa.inspect(pi2).attrs.is_immutable.loaded_value is NO_VALUE
+        assert sa.inspect(pi3).attrs.is_immutable.loaded_value is NO_VALUE
 
         # Immutable columns are immutable even if not loaded
         with pytest.raises(ImmutableColumnError):
@@ -332,19 +323,19 @@ class TestCoasterAnnotations(AppTestCase):
         i2 = IdUuid(is_regular='a', is_immutable='b', is_cached='c')
         i3 = UuidOnly(is_regular='x', is_immutable='y', is_cached='z')
 
-        i1.referral_target_id = rt1.id  # type: ignore[assignment]
-        i2.referral_target_id = rt1.id  # type: ignore[assignment]
-        i3.referral_target_id = rt1.id  # type: ignore[assignment]
+        i1.referral_target_id = rt1.id
+        i2.referral_target_id = rt1.id
+        i3.referral_target_id = rt1.id
 
         self.session.add_all([i1, i2, i3])
         self.session.commit()
 
         # Now try changing the value. i1 and i3 should block, i2 should allow
         with pytest.raises(ImmutableColumnError):
-            i1.referral_target_id = rt2.id  # type: ignore[assignment]
-        i2.referral_target_id = rt2.id  # type: ignore[assignment]
+            i1.referral_target_id = rt2.id
+        i2.referral_target_id = rt2.id
         with pytest.raises(ImmutableColumnError):
-            i3.referral_target_id = rt2.id  # type: ignore[assignment]
+            i3.referral_target_id = rt2.id
 
     def test_immutable_relationship(self) -> None:
         rt1 = ReferralTarget()
@@ -356,9 +347,9 @@ class TestCoasterAnnotations(AppTestCase):
         i2 = IdUuid(is_regular='a', is_immutable='b', is_cached='c')
         i3 = UuidOnly(is_regular='x', is_immutable='y', is_cached='z')
 
-        i1.referral_target_id = rt1.id  # type: ignore[assignment]
-        i2.referral_target_id = rt1.id  # type: ignore[assignment]
-        i3.referral_target_id = rt1.id  # type: ignore[assignment]
+        i1.referral_target_id = rt1.id
+        i2.referral_target_id = rt1.id
+        i3.referral_target_id = rt1.id
 
         self.session.add_all([i1, i2, i3])
         # If we don't commit and flush session cache, i2.referral_target

--- a/tests/coaster_tests/sqlalchemy_models_test.py
+++ b/tests/coaster_tests/sqlalchemy_models_test.py
@@ -320,7 +320,7 @@ class TestCoasterModels(AppTestCase):
     def test_container(self) -> None:
         c = self.make_container()
         assert c.id is None
-        self.session.commit()  # type: ignore[unreachable]
+        self.session.commit()
         assert c.id == 1
 
     def test_timestamp(self) -> None:

--- a/tests/coaster_tests/sqlalchemy_registry_test.py
+++ b/tests/coaster_tests/sqlalchemy_registry_test.py
@@ -202,11 +202,17 @@ def test_registry_reuse_okay() -> None:
 
 
 def test_registry_param_type() -> None:
-    """Registry's param must be string or None."""
+    """Registry's param must be string that is valid as an identifier, or None."""
     r: Registry = Registry()
     assert r._default_kwarg is None
-    with pytest.raises(ValueError, match="kwarg parameter cannot be blank"):
+    with pytest.raises(
+        ValueError, match="kwarg parameter must be a valid Python identifier"
+    ):
         Registry(kwarg='')
+    with pytest.raises(
+        ValueError, match="kwarg parameter must be a valid Python identifier"
+    ):
+        Registry(kwarg='def')
     with pytest.raises(TypeError):
         r = Registry(kwarg=1)  # type: ignore[arg-type]
     r = Registry(kwarg='obj')

--- a/tests/coaster_tests/sqlalchemy_roles_test.py
+++ b/tests/coaster_tests/sqlalchemy_roles_test.py
@@ -43,10 +43,9 @@ from .conftest import AppTestCase, Model
 class DeclaredAttrMixin:
     """Provide `declared_attr` attrs paired with `with_roles`."""
 
-    # pylint: disable=no-self-argument
-
     # with_roles can be used within a declared attr
     @declared_attr
+    @classmethod
     def mixed_in1(cls) -> Mapped[t.Optional[str]]:
         """Test using `with_roles` inside a `declared_attr`."""
         return with_roles(sa.orm.mapped_column(sa.Unicode(250)), rw={'owner'})
@@ -54,6 +53,7 @@ class DeclaredAttrMixin:
     # This previously used the declared_attr_roles decorator, now deprecated and removed
     @with_roles(rw={'owner', 'editor'}, read={'all'})
     @declared_attr
+    @classmethod
     def mixed_in2(cls) -> Mapped[t.Optional[str]]:
         """Test (deprecated) using `with_roles` to wrap a `declared_attr`."""
         return sa.orm.mapped_column(sa.Unicode(250))
@@ -61,6 +61,7 @@ class DeclaredAttrMixin:
     # with_roles can also be used outside a declared attr
     @with_roles(rw={'owner'})
     @declared_attr
+    @classmethod
     def mixed_in3(cls) -> Mapped[t.Optional[str]]:
         """Test using `with_roles` to wrap a `declared_attr`."""
         return sa.orm.mapped_column(sa.Unicode(250))

--- a/tests/coaster_tests/utils_test.py
+++ b/tests/coaster_tests/utils_test.py
@@ -1,5 +1,6 @@
 import datetime
 import typing as t
+import typing_extensions as te
 import unittest
 from collections.abc import MutableSet
 
@@ -330,7 +331,9 @@ class TestCoasterUtils(unittest.TestCase):
             def discard(self, value: t.Any) -> None:
                 return self.set.discard(value)
 
-            update = nary_op(MutableSet.__ior__, "Custom docstring")
+            update: t.ClassVar[t.Callable[..., te.Self]] = nary_op(
+                MutableSet.__ior__, "Custom docstring"
+            )
 
         # Confirm docstrings are added
         assert DemoSet.update.__doc__ == "Custom docstring"

--- a/tests/coaster_tests/views_classview_test.py
+++ b/tests/coaster_tests/views_classview_test.py
@@ -147,7 +147,7 @@ class IndexView(ClassView):
 IndexView.init_app(app)
 
 
-@route('/doc/<name>')
+@route('/doc/<name>', init_app=app)
 class DocumentView(ClassView):
     """Test ClassView for ViewDocument."""
 
@@ -165,9 +165,6 @@ class DocumentView(ClassView):
         document = ViewDocument.query.filter_by(name=name).first_or_404()
         document.title = title
         return 'edited!'
-
-
-DocumentView.init_app(app)
 
 
 class BaseView(ClassView):
@@ -228,7 +225,7 @@ class SubView(BaseView):
 SubView.init_app(app)
 
 
-@route('/secondsub')
+@route('/secondsub', init_app=(app,))
 class AnotherSubView(BaseView):
     """Test second subclass of a ClassView."""
 
@@ -236,9 +233,6 @@ class AnotherSubView(BaseView):
     @BaseView.second.replace
     def second(self):
         return 'also-replaced-second'
-
-
-AnotherSubView.init_app(app)
 
 
 @route('/model/<document>')
@@ -278,7 +272,8 @@ ViewDocument.views.main = ModelDocumentView
 ModelDocumentView.init_app(app)
 
 
-@route('/model/<parent>/<document>')
+@ScopedViewDocument.views('main')
+@route('/model/<parent>/<document>', init_app=app)
 class ScopedDocumentView(ModelDocumentView):
     """Test subclass of a ModelView."""
 
@@ -286,11 +281,8 @@ class ScopedDocumentView(ModelDocumentView):
     route_model_map = {'document': 'name', 'parent': 'parent.name'}
 
 
-ScopedViewDocument.views.main = ScopedDocumentView
-ScopedDocumentView.init_app(app)
-
-
-@route('/rename/<document>')
+@RenameableDocument.views('main')
+@route('/rename/<document>', init_app=app)
 class RenameableDocumentView(
     UrlChangeCheck, UrlForView, InstanceLoader, ModelView[RenameableDocument]
 ):
@@ -302,10 +294,6 @@ class RenameableDocumentView(
     @render_with(json=True)
     def view(self):
         return self.obj.current_access()
-
-
-RenameableDocument.views.main = RenameableDocumentView
-RenameableDocumentView.init_app(app)
 
 
 @route('/multi/<doc1>/<doc2>')
@@ -335,6 +323,7 @@ class MultiDocumentView(UrlForView, ModelView[ViewDocument]):
 MultiDocumentView.init_app(app)
 
 
+@ViewDocument.views('gated')
 @route('/gated/<document>')
 class GatedDocumentView(UrlForView, InstanceLoader, ModelView[ViewDocument]):
     """Test ModelView that has an intercept in before_request."""
@@ -382,7 +371,6 @@ class GatedDocumentView(UrlForView, InstanceLoader, ModelView[ViewDocument]):
         return 'role-perm-called'
 
 
-ViewDocument.views.gated = GatedDocumentView
 GatedDocumentView.init_app(app)
 
 

--- a/tests/coaster_tests/views_classview_test.py
+++ b/tests/coaster_tests/views_classview_test.py
@@ -201,7 +201,8 @@ class SubView(BaseView):
     def first(self):
         return 'rerouted-first'
 
-    @route('2')
+    # Mypy can't process this, but Pyright can. Appears to be a Mypy bug
+    @route('2')  # type: ignore[arg-type]
     @BaseView.second.reroute
     @viewdata(title="Not still second")
     def second(self):
@@ -831,7 +832,7 @@ class TestClassView(unittest.TestCase):
             'edit',  # From ModelDocumentView
             'by_perm',  # From GatedDocumentView (`urls` can't handle permission gating)
         }
-        # Adding acess permissions changes the URLs available
+        # Adding access permissions changes the URLs available
         add_auth_attribute('user', 'this-is-the-owner')  # See ViewDocument.permissions
         assert set(doc1.urls) == {
             # From ModelDocumentView

--- a/tests/coaster_tests/views_classview_test.py
+++ b/tests/coaster_tests/views_classview_test.py
@@ -279,7 +279,7 @@ ModelDocumentView.init_app(app)
 class ScopedDocumentView(ModelDocumentView):
     """Test subclass of a ModelView."""
 
-    model: t.ClassVar = ScopedViewDocument
+    model = ScopedViewDocument  # type: ignore[assignment,misc]
     route_model_map = {'document': 'name', 'parent': 'parent.name'}
 
 
@@ -390,9 +390,9 @@ def test_modelview_generic_model() -> None:
     """Test ModelView[model] is copied to attr model."""
     assert ModelDocumentView.model is ViewDocument
     assert RenameableDocumentView.model is RenameableDocument
-    assert MultiDocumentView.model is ViewDocument
+    assert MultiDocumentView.model is ViewDocument  # type: ignore[misc]
     assert GatedDocumentView.model is ViewDocument
-    assert ScopedDocumentView.model is ScopedViewDocument  # Not overridden
+    assert ScopedDocumentView.model is ScopedViewDocument  # type: ignore[has-type]
 
 
 class TestClassView(unittest.TestCase):

--- a/tests/coaster_tests/views_classview_test.py
+++ b/tests/coaster_tests/views_classview_test.py
@@ -309,7 +309,12 @@ RenameableDocumentView.init_app(app)
 class MultiDocumentView(UrlForView, ModelView[ViewDocument]):
     """Test ModelView that has multiple documents."""
 
-    route_model_map = {'doc1': 'name', 'doc2': '**doc2.url_name'}
+    route_model_map = {'doc2': '**doc2.url_name'}
+
+    class GetAttr:
+        @staticmethod
+        def doc1(obj: ViewDocument) -> str:
+            return obj.name
 
     def loader(  # type: ignore[override]  # pylint: disable=arguments-differ
         self, doc1: str, doc2: str


### PR DESCRIPTION
ClassView still contained some legacy architecture from the Python 2.7 era. These upgrades use 3.x idioms and add or fix type hinting support.

Unrelated fixes in other modules were noticed when working on ClassView.