### PR TITLE
Improve typing coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,44 @@
+# Hasgeek code style config
+root = True
+
+# For all files
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# For all code, config and documentation
+[*.{js,py,jinja2,j2,html,xml,css,sass,scss,json,yml,md,rst}]
+charset = utf-8
+indent_style = space
+tab_width = 8
+max_line_length = 88
+
+# Python code
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# JavaScript and HTML/CSS
+[*.{js,js.jinja2,html.jinja2,xml.jinja2,j2,html,xml,css,sass,scss}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Makefile
+[Makefile]
+indent_style = tab
+indent_size = tab
+trim_trailing_whitespace = true
+
+# Config
+[*.{json,toml,yml,yaml}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Documentation
+[*.{md,rst,md.jinja2}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ test.db
 .settings
 *.egg-info
 .coverage
+coverage/
+coverage.xml
 docs/_build
 build/
 dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,12 @@ repos:
       - id: mypy
         # warn-unused-ignores is unsafe with pre-commit, see
         # https://github.com/python/mypy/issues/2960
-        args: ['--no-warn-unused-ignores', '--ignore-missing-imports']
+        args:
+          [
+            '--no-warn-unused-ignores',
+            '--no-warn-redundant-casts',
+            '--ignore-missing-imports',
+          ]
         additional_dependencies:
           - flask
           - lxml-stubs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,12 @@ repos:
     hooks:
       - id: prettier
         args: ['--single-quote', '--trailing-comma', 'es5']
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
+    hooks:
+      - id: shellcheck
+        args:
+          - --external-sources
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,8 @@ ignore_missing_imports = true
 show_error_codes = true
 warn_unreachable = true
 warn_unused_ignores = true
-warn_redundant_casts = false
-check_untyped_defs = false
+warn_redundant_casts = true
+check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = 'tests.*'

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+formats: all
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/src/coaster/app.py
+++ b/src/coaster/app.py
@@ -262,7 +262,9 @@ def init_app(
         app.json = JSONProvider(app)
         app.jinja_env.policies['json.dumps_function'] = app.json.dumps
     # Make current_auth available to app templates
-    app.jinja_env.globals['current_auth'] = current_auth
+    if 'current_auth' not in app.jinja_env.globals:
+        # Don't override if the app installed a custom proxy
+        app.jinja_env.globals['current_auth'] = current_auth
     # Make the current view available to app templates
     app.jinja_env.globals['current_view'] = current_view
     # Disable Flask-SQLAlchemy events.

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -70,7 +70,7 @@ from .functions import auto_init_default, failsafe_add
 from .immutable_annotation import immutable
 from .model import Query, QueryProperty
 from .registry import RegistryMixin
-from .roles import RoleMixin, with_roles
+from .roles import ActorType, RoleMixin, with_roles
 
 __all__ = [
     'PkeyType',
@@ -665,7 +665,9 @@ class UrlForMixin:
 
 
 @declarative_mixin
-class NoIdMixin(TimestampMixin, PermissionMixin, RoleMixin, RegistryMixin, UrlForMixin):
+class NoIdMixin(
+    TimestampMixin, PermissionMixin, RoleMixin[ActorType], RegistryMixin, UrlForMixin
+):
     """
     Mixin that combines all mixin classes except :class:`IdMixin`.
 
@@ -685,12 +687,12 @@ class NoIdMixin(TimestampMixin, PermissionMixin, RoleMixin, RegistryMixin, UrlFo
 
 
 @declarative_mixin
-class BaseMixin(IdMixin[PkeyType], NoIdMixin):
+class BaseMixin(IdMixin[PkeyType], NoIdMixin[ActorType]):
     """Base mixin class for all tables that have an id column."""
 
 
 @declarative_mixin
-class BaseNameMixin(BaseMixin[PkeyType]):
+class BaseNameMixin(BaseMixin[PkeyType, ActorType]):
     """
     Base mixin class for named objects.
 
@@ -830,7 +832,7 @@ class BaseNameMixin(BaseMixin[PkeyType]):
 
 
 @declarative_mixin
-class BaseScopedNameMixin(BaseMixin[PkeyType]):
+class BaseScopedNameMixin(BaseMixin[PkeyType, ActorType]):
     """
     Base mixin class for named objects within containers.
 
@@ -1018,7 +1020,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType]):
 
 
 @declarative_mixin
-class BaseIdNameMixin(BaseMixin[PkeyType]):
+class BaseIdNameMixin(BaseMixin[PkeyType, ActorType]):
     """
     Base mixin class for named objects with an id tag.
 
@@ -1142,7 +1144,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType]):
 
 
 @declarative_mixin
-class BaseScopedIdMixin(BaseMixin[PkeyType]):
+class BaseScopedIdMixin(BaseMixin[PkeyType, ActorType]):
     """
     Base mixin class for objects with an id that is unique within a parent.
 
@@ -1212,7 +1214,7 @@ class BaseScopedIdMixin(BaseMixin[PkeyType]):
 
 
 @declarative_mixin
-class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType]):
+class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType, ActorType]):
     """
     Base mixin class for named objects with an id tag that is unique within a parent.
 

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -32,7 +32,7 @@ from collections import abc
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import cast, overload
+from typing import overload
 from uuid import UUID, uuid4
 
 from flask import current_app, url_for
@@ -208,13 +208,13 @@ class IdMixin(t.Generic[PkeyType]):
 
     @declared_attr
     @classmethod
-    def url_id(cls) -> Mapped[str]:
+    def url_id(cls) -> hybrid_property[str]:
         """URL-safe representation of the id value, using hex for a UUID id."""
         if cls.__uuid_primary_key__:
 
             def url_id_uuid_func(self: te.Self) -> str:
                 """URL-safe representation of the UUID id as a hex value."""
-                return cast(UUID, self.id).hex
+                return self.id.hex  # type: ignore[attr-defined]
 
             def url_id_uuid_comparator(cls: t.Type) -> SqlUuidHexComparator:
                 """Compare two hex UUID values."""
@@ -225,7 +225,7 @@ class IdMixin(t.Generic[PkeyType]):
             url_id_property = hybrid_property(url_id_uuid_func).comparator(
                 url_id_uuid_comparator
             )
-            return url_id_property  # type: ignore[return-value]
+            return url_id_property
 
         def url_id_int_func(self: te.Self) -> str:
             """URL-safe representation of the integer id as a string."""
@@ -240,7 +240,7 @@ class IdMixin(t.Generic[PkeyType]):
         url_id_property = hybrid_property(url_id_int_func).comparator(
             url_id_int_comparator
         )
-        return url_id_property  # type: ignore[return-value]
+        return url_id_property
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} {self.id}>'

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -202,10 +202,16 @@ class IdMixin(t.Generic[PkeyType]):
         """Database identity for this model."""
         if cls.__uuid_primary_key__:
             return sa.orm.mapped_column(
-                sa.Uuid, default=uuid4, primary_key=True, nullable=False
+                sa.Uuid,
+                default=None,
+                insert_default=uuid4,
+                primary_key=True,
+                nullable=False,
             )
 
-        return sa.orm.mapped_column(sa.Integer, primary_key=True, nullable=False)
+        return sa.orm.mapped_column(
+            sa.Integer, primary_key=True, nullable=False, default=None
+        )
 
     # Compatibility alias for use in Protocols, as a workaround for Mypy incorrectly
     # considering `id` to be read-only: https://github.com/python/mypy/issues/16709
@@ -357,7 +363,8 @@ class TimestampMixin:
         """Timestamp for when this instance was created, in UTC."""
         return sa.orm.mapped_column(
             sa.TIMESTAMP(timezone=cls.__with_timezone__),
-            default=func.utcnow(),
+            insert_default=func.utcnow(),
+            default=None,
             nullable=False,
         )
 
@@ -369,7 +376,8 @@ class TimestampMixin:
         """Timestamp for when this instance was last updated (via the app), in UTC."""
         return sa.orm.mapped_column(
             sa.TIMESTAMP(timezone=cls.__with_timezone__),
-            default=func.utcnow(),
+            insert_default=func.utcnow(),
+            default=None,
             onupdate=func.utcnow(),
             nullable=False,
         )

--- a/src/coaster/sqlalchemy/mixins.py
+++ b/src/coaster/sqlalchemy/mixins.py
@@ -213,7 +213,7 @@ class IdMixin(t.Generic[PkeyType]):
     def __id_(cls) -> Mapped[t.Any]:  # Define type as `Any` for use in Protocols
         return synonym('id')
 
-    id_ = declared_attr(__id_)
+    id_: declared_attr[t.Any] = declared_attr(__id_)
     del __id_
 
     @classmethod
@@ -251,7 +251,7 @@ class IdMixin(t.Generic[PkeyType]):
         )
         return url_id_property
 
-    url_id = declared_attr(__url_id)
+    url_id: declared_attr[str] = declared_attr(__url_id)
     del __url_id
 
     def __repr__(self) -> str:
@@ -286,7 +286,9 @@ class UuidMixin:
             return synonym('id')
         return sa.orm.mapped_column(sa.Uuid, default=uuid4, unique=True, nullable=False)
 
-    uuid = immutable(with_roles(declared_attr(__uuid), read={'all'}))
+    uuid: declared_attr[UUID] = immutable(
+        with_roles(declared_attr(__uuid), read={'all'})
+    )
     del __uuid
 
     @hybrid_property
@@ -359,7 +361,7 @@ class TimestampMixin:
             nullable=False,
         )
 
-    created_at = immutable(declared_attr(__created_at))
+    created_at: declared_attr[datetime] = immutable(declared_attr(__created_at))
     del __created_at
 
     @classmethod
@@ -372,7 +374,7 @@ class TimestampMixin:
             nullable=False,
         )
 
-    updated_at = declared_attr(__updated_at)
+    updated_at: declared_attr[datetime] = declared_attr(__updated_at)
     del __updated_at
 
 
@@ -735,7 +737,7 @@ class BaseNameMixin(BaseMixin[PkeyType, ActorType]):
             column_type, sa.CheckConstraint("name <> ''"), nullable=False, unique=True
         )
 
-    name = declared_attr(__name)
+    name: declared_attr[str] = declared_attr(__name)
     del __name
 
     @classmethod
@@ -747,7 +749,7 @@ class BaseNameMixin(BaseMixin[PkeyType, ActorType]):
             column_type = sa.Unicode(cls.__title_length__)
         return sa.orm.mapped_column(column_type, nullable=False)
 
-    title = declared_attr(__title)
+    title: declared_attr[str] = declared_attr(__title)
     del __title
 
     @property
@@ -891,7 +893,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType, ActorType]):
             column_type, sa.CheckConstraint("name <> ''"), nullable=False
         )
 
-    name = declared_attr(__name)
+    name: declared_attr[str] = declared_attr(__name)
     del __name
 
     @classmethod
@@ -903,7 +905,7 @@ class BaseScopedNameMixin(BaseMixin[PkeyType, ActorType]):
             column_type = sa.Unicode(cls.__title_length__)
         return sa.orm.mapped_column(column_type, nullable=False)
 
-    title = declared_attr(__title)
+    title: declared_attr[str] = declared_attr(__title)
     del __title
 
     def __init__(self, *args, **kw) -> None:
@@ -1061,7 +1063,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType, ActorType]):
             column_type, sa.CheckConstraint("name <> ''"), nullable=False
         )
 
-    name = declared_attr(__name)
+    name: declared_attr[str] = declared_attr(__name)
     del __name
 
     @classmethod
@@ -1073,7 +1075,7 @@ class BaseIdNameMixin(BaseMixin[PkeyType, ActorType]):
             column_type = sa.Unicode(cls.__title_length__)
         return sa.orm.mapped_column(column_type, nullable=False)
 
-    title = declared_attr(__title)
+    title: declared_attr[str] = declared_attr(__title)
     del __title
 
     @property
@@ -1171,7 +1173,9 @@ class BaseScopedIdMixin(BaseMixin[PkeyType, ActorType]):
         return sa.orm.mapped_column(sa.Integer, nullable=False)
 
     # IdMixin defined `url_id` as `str`, so we need a type-ignore to change to `int`
-    url_id = with_roles(declared_attr(__url_id), read={'all'})  # type: ignore[arg-type]
+    url_id: declared_attr[int] = with_roles(  # type: ignore[assignment]
+        declared_attr(__url_id), read={'all'}
+    )
     del __url_id
 
     def __init__(self, *args, **kw) -> None:
@@ -1268,7 +1272,7 @@ class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType, ActorType]):
             column_type, sa.CheckConstraint("name <> ''"), nullable=False
         )
 
-    name = declared_attr(__name)
+    name: declared_attr[str] = declared_attr(__name)
     del __name
 
     @classmethod
@@ -1280,7 +1284,7 @@ class BaseScopedIdNameMixin(BaseScopedIdMixin[PkeyType, ActorType]):
             column_type = sa.Unicode(cls.__title_length__)
         return sa.orm.mapped_column(column_type, nullable=False)
 
-    title = declared_attr(__title)
+    title: declared_attr[str] = declared_attr(__title)
     del __title
 
     @property

--- a/src/coaster/sqlalchemy/model.py
+++ b/src/coaster/sqlalchemy/model.py
@@ -106,7 +106,7 @@ __all__ = [
     'QueryProperty',
     'AppenderQuery',
     'ModelBase',
-    'DeclarativeBase',
+    'DeclarativeBase',  # From SQLAlchemy, re-exported for convenience
     'DynamicMapped',
     'Relationship',
     'relationship',

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -1350,13 +1350,13 @@ class RoleMixin:
 
     @overload
     def actors_with(
-        self, roles: t.Iterable[str], with_role: te.Literal[True] = True
+        self, roles: t.Iterable[str], with_role: te.Literal[True]
     ) -> t.Iterator[t.Tuple[t.Any, str]]:
         ...
 
     def actors_with(
         self, roles: t.Iterable[str], with_role: bool = False
-    ) -> t.Iterator[t.Union[t.Any, t.Tuple[str, t.Any]]]:
+    ) -> t.Iterator[t.Union[t.Any, t.Tuple[t.Any, str]]]:
         """
         Return actors who have the specified roles on this object, as an iterator.
 

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -39,6 +39,7 @@ Example use::
         demonstrating two ways to use `with_roles`.
         '''
         @with_roles(rw={'owner'})
+        @declared_attr
         def mixed_in1(cls) -> Mapped[str]:
             return sa.orm.mapped_column(sa.Unicode(250))
 

--- a/src/coaster/sqlalchemy/roles.py
+++ b/src/coaster/sqlalchemy/roles.py
@@ -1612,7 +1612,7 @@ def _configure_roles(_mapper: t.Any, cls: t.Type[RoleMixin]) -> None:
                 attr, (QueryableAttribute, RelationshipProperty, MapperProperty)
             ):
                 if attr.property in __cache__:
-                    data = cast(WithRoles, __cache__[attr.property])
+                    data = __cache__[attr.property]
                 elif '_coaster_roles' in attr.info:
                     data = cast(WithRoles, attr.info['_coaster_roles'])
                 elif hasattr(attr.property, '_coaster_roles'):

--- a/src/coaster/utils/markdown.py
+++ b/src/coaster/utils/markdown.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import typing as t
 from copy import deepcopy
 from html import unescape
-from typing import cast, overload
+from typing import overload
 from xml.etree.ElementTree import Element  # nosec B405
 
 from bleach import linkify as linkify_processor
@@ -47,7 +47,7 @@ __all__ = [
 # --- Constants ------------------------------------------------------------------------
 
 MARKDOWN_HTML_TAGS = deepcopy(VALID_TAGS)
-cast(t.Dict, MARKDOWN_HTML_TAGS).update(
+MARKDOWN_HTML_TAGS.update(
     {
         # For tables:
         'table': ['align', 'bgcolor', 'border', 'cellpadding', 'cellspacing', 'width'],
@@ -222,14 +222,14 @@ def markdown(
                     output_format='html',
                     extensions=extensions,
                     extension_configs=extension_configs,
-                ).convert(cast(str, text)),
+                ).convert(text),
                 valid_tags=valid_tags,
                 linkify=linkify,
             )
         )
     output = Markdown(
         output_format='html', extensions=extensions, extension_configs=extension_configs
-    ).convert(cast(str, text))
+    ).convert(text)
     if linkify:
         output = linkify_processor(
             output,

--- a/tests/coaster_tests/auth_test.py
+++ b/tests/coaster_tests/auth_test.py
@@ -3,12 +3,10 @@
 
 import typing as t
 from types import SimpleNamespace
-from typing import cast
 
 import pytest
 import sqlalchemy as sa
 from flask import Flask, g, has_request_context, render_template_string
-from flask.ctx import RequestContext
 from sqlalchemy.orm import Mapped
 
 from coaster.auth import (
@@ -113,7 +111,7 @@ def flask_login_manager(app: Flask) -> t.Iterator[FlaskLoginManager]:
 @pytest.fixture()
 def request_ctx(app: Flask) -> t.Iterator:
     """Request context with database models."""
-    ctx = cast(RequestContext, app.test_request_context())
+    ctx = app.test_request_context()
     ctx.push()
     db.create_all()
     yield ctx

--- a/tests/coaster_tests/conftest.py
+++ b/tests/coaster_tests/conftest.py
@@ -62,7 +62,7 @@ class AppTestCase(unittest.TestCase):  # skipcq: PTC-W0046
 
     def setUp(self) -> None:
         """Prepare test context."""
-        self.ctx = t.cast(RequestContext, self.app.test_request_context())
+        self.ctx = self.app.test_request_context()
         self.ctx.push()
         db.create_all()
         self.session = t.cast(sa.orm.Session, db.session)

--- a/tests/coaster_tests/sqlalchemy_annotations_test.py
+++ b/tests/coaster_tests/sqlalchemy_annotations_test.py
@@ -26,7 +26,7 @@ class ReferralTarget(BaseMixin, Model):
     __tablename__ = 'referral_target'
 
 
-class IdOnly(BaseMixin[int], Model):
+class IdOnly(BaseMixin[int, t.Any], Model):
     __tablename__ = 'id_only'
 
     is_regular: Mapped[t.Optional[int]] = sa.orm.mapped_column(sa.Integer)
@@ -40,7 +40,7 @@ class IdOnly(BaseMixin[int], Model):
     referral_target: Mapped[t.Optional[ReferralTarget]] = relationship(ReferralTarget)
 
 
-class IdUuid(UuidMixin, BaseMixin[int], Model):
+class IdUuid(UuidMixin, BaseMixin[int, t.Any], Model):
     __tablename__ = 'id_uuid'
 
     is_regular: Mapped[t.Optional[str]] = sa.orm.mapped_column(sa.Unicode(250))
@@ -58,7 +58,7 @@ class IdUuid(UuidMixin, BaseMixin[int], Model):
     )
 
 
-class UuidOnly(UuidMixin, BaseMixin[int], Model):
+class UuidOnly(UuidMixin, BaseMixin[int, t.Any], Model):
     __tablename__ = 'uuid_only'
 
     is_regular: Mapped[t.Optional[str]] = sa.orm.mapped_column(sa.Unicode(250))

--- a/tests/coaster_tests/sqlalchemy_models_test.py
+++ b/tests/coaster_tests/sqlalchemy_models_test.py
@@ -220,50 +220,50 @@ class MyUrlModel(Model):
     )
 
 
-class NonUuidKey(BaseMixin[int], Model):
+class NonUuidKey(BaseMixin[int, t.Any], Model):
     __tablename__ = 'non_uuid_key'
 
 
-class UuidKey(BaseMixin[UUID], Model):
+class UuidKey(BaseMixin[UUID, t.Any], Model):
     __tablename__ = 'uuid_key'
 
 
-class UuidKeyNoDefault(BaseMixin[UUID], Model):
+class UuidKeyNoDefault(BaseMixin[UUID, t.Any], Model):
     __tablename__ = 'uuid_key_no_default'
     id: Mapped[UUID] = sa.orm.mapped_column(  # type: ignore[assignment]  # noqa: A003
         sa.Uuid, primary_key=True
     )
 
 
-class UuidForeignKey1(BaseMixin[int], Model):
+class UuidForeignKey1(BaseMixin[int, t.Any], Model):
     __tablename__ = 'uuid_foreign_key1'
     uuidkey_id: Mapped[UUID] = sa.orm.mapped_column(sa.ForeignKey('uuid_key.id'))
     uuidkey: Mapped[UuidKey] = relationship(UuidKey)
 
 
-class UuidForeignKey2(BaseMixin[UUID], Model):
+class UuidForeignKey2(BaseMixin[UUID, t.Any], Model):
     __tablename__ = 'uuid_foreign_key2'
     uuidkey_id: Mapped[UUID] = sa.orm.mapped_column(sa.ForeignKey('uuid_key.id'))
     uuidkey: Mapped[UuidKey] = relationship(UuidKey)
 
 
-class UuidIdName(BaseIdNameMixin[UUID], Model):
+class UuidIdName(BaseIdNameMixin[UUID, t.Any], Model):
     __tablename__ = 'uuid_id_name'
 
 
-class UuidIdNameMixin(UuidMixin, BaseIdNameMixin[UUID], Model):
+class UuidIdNameMixin(UuidMixin, BaseIdNameMixin[UUID, t.Any], Model):
     __tablename__ = 'uuid_id_name_mixin'
 
 
-class UuidIdNameSecondary(UuidMixin, BaseIdNameMixin[int], Model):
+class UuidIdNameSecondary(UuidMixin, BaseIdNameMixin[int, t.Any], Model):
     __tablename__ = 'uuid_id_name_secondary'
 
 
-class NonUuidMixinKey(UuidMixin, BaseMixin[int], Model):
+class NonUuidMixinKey(UuidMixin, BaseMixin[int, t.Any], Model):
     __tablename__ = 'non_uuid_mixin_key'
 
 
-class UuidMixinKey(UuidMixin, BaseMixin[UUID], Model):
+class UuidMixinKey(UuidMixin, BaseMixin[UUID, t.Any], Model):
     __tablename__ = 'uuid_mixin_key'
 
 

--- a/tests/coaster_tests/statemanager_test.py
+++ b/tests/coaster_tests/statemanager_test.py
@@ -201,15 +201,27 @@ def test_check_constraint_labeledenum():
         MAYBE = ('m', "Maybe")
 
     assert (
-        str(StateManager.check_constraint('state', TestEnum1).sqltext)
+        str(
+            StateManager.check_constraint('state', TestEnum1).sqltext.compile(
+                compile_kwargs={'literal_binds': True}
+            )
+        )
         == 'state IN (1, 2, 3)'
     )
     assert (
-        str(StateManager.check_constraint('state', TestEnum2).sqltext)
+        str(
+            StateManager.check_constraint('state', TestEnum2).sqltext.compile(
+                compile_kwargs={'literal_binds': True}
+            )
+        )
         == 'state IN (1, 2, 3)'
     )
     assert (
-        str(StateManager.check_constraint('state', TestEnumStr).sqltext)
+        str(
+            StateManager.check_constraint('state', TestEnumStr).sqltext.compile(
+                compile_kwargs={'literal_binds': True}
+            )
+        )
         == "state IN ('y', 'n', 'm')"
     )
 
@@ -246,21 +258,35 @@ def test_check_constraint_enum():
         MAYBE = 'm', "Maybe"
 
     assert (
-        str(StateManager.check_constraint('state', TestEnumInt).sqltext)
-        == 'state IN (1, 2, 3)'
-    )
-    assert (
         str(
-            StateManager.check_constraint('state', TestEnumIntLabel, sa.Integer).sqltext
+            StateManager.check_constraint('state', TestEnumInt).sqltext.compile(
+                compile_kwargs={'literal_binds': True}
+            )
         )
         == 'state IN (1, 2, 3)'
     )
     assert (
-        str(StateManager.check_constraint('state', TestEnumStr).sqltext)
+        str(
+            StateManager.check_constraint(
+                'state', TestEnumIntLabel, sa.Integer
+            ).sqltext.compile(compile_kwargs={'literal_binds': True})
+        )
+        == 'state IN (1, 2, 3)'
+    )
+    assert (
+        str(
+            StateManager.check_constraint('state', TestEnumStr).sqltext.compile(
+                compile_kwargs={'literal_binds': True}
+            )
+        )
         == "state IN ('y', 'n', 'm')"
     )
     assert (
-        str(StateManager.check_constraint('state', TestEnumStrLabel, sa.String).sqltext)
+        str(
+            StateManager.check_constraint(
+                'state', TestEnumStrLabel, sa.String
+            ).sqltext.compile(compile_kwargs={'literal_binds': True})
+        )
         == "state IN ('y', 'n', 'm')"
     )
 
@@ -328,7 +354,7 @@ class TestStateManager(AppTestCase):
             state.transition(state.DRAFT, state.REDRAFTABLE)(lambda: None)
 
     def test_has_state(self) -> None:
-        """A post has a state that can be tested with statemanager.NAME."""
+        """A post has a state that can be tested with state_manager.NAME."""
         assert self.post._state == MY_STATE.DRAFT
         assert self.post.state.value == MY_STATE.DRAFT
         assert self.post.state.DRAFT

--- a/tests/coaster_tests/url_for_test.py
+++ b/tests/coaster_tests/url_for_test.py
@@ -1,7 +1,6 @@
 """Tests for urlForMixin."""
 
 import unittest
-from typing import cast
 
 import pytest
 from flask import Flask
@@ -91,7 +90,7 @@ class TestUrlForBase(unittest.TestCase):
     ctx: RequestContext
 
     def setUp(self) -> None:
-        self.ctx = cast(RequestContext, self.app.test_request_context())
+        self.ctx = self.app.test_request_context()
         self.ctx.push()
         db.create_all()
         self.session = db.session

--- a/tests/coaster_tests/views_classview_test.py
+++ b/tests/coaster_tests/views_classview_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import typing as t
 import unittest
-from typing import cast
 
 import pytest
 import sqlalchemy as sa
@@ -116,6 +115,7 @@ class IndexView(ClassView):
     """Test ClassView."""
 
     @route('')
+    @route('/index.html')
     @viewdata(title="Index")
     def index(self) -> str:
         return 'index'
@@ -301,6 +301,7 @@ class MultiDocumentView(UrlForView, ModelView[ViewDocument]):
     """Test ModelView that has multiple documents."""
 
     route_model_map = {'doc2': '**doc2.url_name'}
+    obj: t.Tuple[ViewDocument, RenameableDocument]  # type: ignore[assignment]
 
     class GetAttr:
         @staticmethod
@@ -393,7 +394,7 @@ class TestClassView(unittest.TestCase):
     ctx: RequestContext
 
     def setUp(self) -> None:
-        self.ctx = cast(RequestContext, self.app.test_request_context())
+        self.ctx = self.app.test_request_context()
         self.ctx.push()
         db.create_all()
         self.session = db.session

--- a/tests/coaster_tests/views_classview_test.py
+++ b/tests/coaster_tests/views_classview_test.py
@@ -102,7 +102,7 @@ class ScopedViewDocument(BaseScopedNameMixin, Model):
 
 
 # Use serial int pkeys so that we can get consistent `1-<name>` url_name in tests
-class RenameableDocument(BaseIdNameMixin[int], Model):
+class RenameableDocument(BaseIdNameMixin[int, t.Any], Model):
     __tablename__ = 'renameable_document'
     __roles__ = {'all': {'read': {'name', 'title'}}}
 

--- a/tests/coaster_tests/views_endpointfor_test.py
+++ b/tests/coaster_tests/views_endpointfor_test.py
@@ -2,7 +2,6 @@
 
 import typing as t
 import unittest
-from typing import cast
 
 from flask import Flask
 from flask.ctx import RequestContext
@@ -29,7 +28,7 @@ class TestScaffolding(unittest.TestCase):
         if self.server_name:
             self.app.config['SERVER_NAME'] = self.server_name
 
-        self.ctx = cast(RequestContext, self.app.test_request_context())
+        self.ctx = self.app.test_request_context()
         self.ctx.push()
 
     def tearDown(self) -> None:


### PR DESCRIPTION
* `current_auth` is now intended to be subclassed by apps so they can specify types for the `actor` and `user` attributes.
* `StateManager` now accepts an Enum instead of a LabeledEnum (partially).
* `RoleMixin` is now a generic on the actor type. Unfortunately this interferes with `IdMixin`'s generic arg, so any class that specifies `UUID` pkey type must also explicitly list the actor type, and conversely when specifying the actor on a table with an int pkey, `int` must be explicitly specified. Where both are unspecified, it defaults to `int` pkey and `Any` actor:
    * `BaseMixin` is the same as `BaseMixin[int, Any]`.
    * `BaseMixin[UUID]` is now an error as the second arg is missing. [PEP 696](https://peps.python.org/pep-0696/) explicitly allows this, but the PEP is a draft and implementations are incomplete.
    * `BaseMixin[..., ActorType]` is not an option as defaults can only be specified at the end. `BaseMixin[int, ActorType]` should be used to get the (previously default) `int` pkey.
* To workaround a Mypy bug (https://github.com/python/mypy/issues/16709), all uses of `declared_attr` now avoid the standard decorator convention and define it as an attribute. Unfortunately, this seems to trigger a Pyright bug in Protocols where it types the `declared_attr` on the basis of `declared_attr.__get__`'s union return type, instead of matching the context (class-level or instance-level access). A bug report is pending. We use Mypy in CI and pre-commit checks but not Pyright, so the Pyright bug is not a blocker.