### PR TITLE
Minor cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
             '--remove-duplicate-keys',
           ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.7
+    rev: v0.4.1
     hooks:
       - id: ruff
         args: ['--fix', '--exit-non-zero-on-fix']
@@ -51,11 +51,11 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.1
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: mypy
         # warn-unused-ignores is unsafe with pre-commit, see

--- a/src/coaster/app.py
+++ b/src/coaster/app.py
@@ -109,7 +109,7 @@ if mod_yaml is not None:
     _config_loaders['yml'] = ConfigLoader(extn='.yml', loader=mod_yaml.safe_load)
 
 
-_S = TypeVar('_S', bound=itsdangerous.Serializer)
+_S = TypeVar('_S', bound='itsdangerous.Serializer[Any]')
 
 
 _sentinel_keyrotation_exception = RuntimeError("KeyRotationWrapper has no engines.")

--- a/src/coaster/assets.py
+++ b/src/coaster/assets.py
@@ -22,7 +22,7 @@ import re
 import warnings
 from collections import defaultdict
 from collections.abc import Iterator, Mapping, Sequence
-from typing import Any, Optional, Union
+from typing import Any, Final, Optional, Union
 from urllib.parse import urljoin
 
 from flask import Flask, current_app
@@ -37,6 +37,7 @@ __all__ = [
     'SimpleSpec',
     'VersionedAssets',
     'AssetNotFound',
+    'AssetNotFoundError',
     'WebpackManifest',
 ]
 
@@ -52,8 +53,11 @@ def split_namespec(namespec: str) -> tuple[str, SimpleSpec]:
     return name, spec
 
 
-class AssetNotFound(Exception):  # noqa: N818
+class AssetNotFoundError(Exception):
     """No asset with this name."""
+
+
+AssetNotFound = AssetNotFoundError
 
 
 class VersionedAssets(defaultdict):
@@ -186,7 +190,7 @@ class VersionedAssets(defaultdict):
                     if bundle is not None:
                         bundles.append((name, version, bundle))
             else:
-                raise AssetNotFound(namespec)
+                raise AssetNotFoundError(namespec)
         return bundles
 
     def require(self, *namespecs: str) -> Bundle:
@@ -202,7 +206,7 @@ class VersionedAssets(defaultdict):
         )
 
 
-EXTENSION_KEY = 'manifest.json'
+EXTENSION_KEY: Final[str] = 'manifest.json'
 
 
 def _get_assets_for_current_app() -> dict[str, str]:

--- a/src/coaster/logger.py
+++ b/src/coaster/logger.py
@@ -286,7 +286,7 @@ class SlackHandler(logging.Handler):
             throttle_key = (record.module, record.lineno)
             with self.throttle_lock:
                 if throttle_key in self.throttle_cache and (
-                    (datetime.utcnow() - self.throttle_cache[throttle_key])
+                    (datetime.now() - self.throttle_cache[throttle_key])
                     < timedelta(minutes=5)
                 ):
                     return
@@ -349,7 +349,7 @@ class SlackHandler(logging.Handler):
                     daemon=True,
                 ).start()
             with self.throttle_lock:
-                self.throttle_cache[throttle_key] = datetime.utcnow()
+                self.throttle_cache[throttle_key] = datetime.now()
         except Exception:  # nosec  # noqa: B902  # pylint: disable=broad-except
             self.handleError(record)
 
@@ -375,7 +375,7 @@ class TelegramHandler(logging.Handler):
             throttle_key = (record.module, record.lineno)
             with self.throttle_lock:
                 if throttle_key in self.throttle_cache and (
-                    (datetime.utcnow() - self.throttle_cache[throttle_key])
+                    (datetime.now() - self.throttle_cache[throttle_key])
                     < timedelta(minutes=5)
                 ):
                     return
@@ -424,7 +424,7 @@ class TelegramHandler(logging.Handler):
                 daemon=True,
             ).start()
             with self.throttle_lock:
-                self.throttle_cache[throttle_key] = datetime.utcnow()
+                self.throttle_cache[throttle_key] = datetime.now()
         except Exception:  # noqa: B902  # pylint: disable=broad-except
             self.handleError(record)
 

--- a/src/coaster/sqlalchemy/registry.py
+++ b/src/coaster/sqlalchemy/registry.py
@@ -177,7 +177,7 @@ class Registry:
     ) -> ReturnDecorator:
         """Return decorator to aid class or function registration."""
         # Using the final-decorated Unspecified class as a sentinel value works in
-        # Pyright but not yet in Mypy as of 1.9.0. Therefore we use the non-singleton
+        # Pyright but not yet in Mypy as of 1.10.0. Therefore we use the non-singleton
         # instance instead. Issue ticket: https://github.com/python/mypy/issues/15553
         use_kwarg = self._default_kwarg if isinstance(kwarg, Unspecified) else kwarg
         use_property = self._default_property if property is None else property


### PR DESCRIPTION
~~Defer locking to the GIL instead (borrowing from the change to `functools.cached_property` in Python 3.12). Also,~~ Avoid `datetime.utcnow()` and use a final class as a sentinel singleton.